### PR TITLE
feature: Use the newer NetworkCallback API on versions of Android which support it

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/BroadcastReceiverConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/BroadcastReceiverConnectivityReceiver.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.reactnativecommunity.netinfo;
+
+import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+
+/**
+ * This gets the connectivity status using a BroadcastReceiver. This method was deprecated
+ * on Android from API level 24 (N) but we use this method still for any devices running below
+ * level 24.
+ *
+ * It has a few differences from the new NetworkCallback method:
+ * - Changes to the cellular network effective type (eg. from 2g to 3g) will not trigger a callback
+ */
+@SuppressWarnings("deprecation")
+public class BroadcastReceiverConnectivityReceiver extends ConnectivityReceiver {
+  private final ConnectivityBroadcastReceiver mConnectivityBroadcastReceiver;
+
+  public BroadcastReceiverConnectivityReceiver(ReactApplicationContext reactContext) {
+    super(reactContext);
+    mConnectivityBroadcastReceiver = new ConnectivityBroadcastReceiver();
+  }
+
+  @Override
+  public void register() {
+    IntentFilter filter = new IntentFilter();
+    filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+    getReactContext().registerReceiver(mConnectivityBroadcastReceiver, filter);
+    mConnectivityBroadcastReceiver.setRegistered(true);
+    updateAndSendConnectionType();
+  }
+
+  @Override
+  public void unregister() {
+    if (mConnectivityBroadcastReceiver.isRegistered()) {
+      getReactContext().unregisterReceiver(mConnectivityBroadcastReceiver);
+      mConnectivityBroadcastReceiver.setRegistered(false);
+    }
+  }
+
+  @SuppressLint("MissingPermission")
+  private void updateAndSendConnectionType() {
+    String connectionType = CONNECTION_TYPE_UNKNOWN;
+    String effectiveConnectionType = EFFECTIVE_CONNECTION_TYPE_UNKNOWN;
+
+    try {
+      NetworkInfo networkInfo = getConnectivityManager().getActiveNetworkInfo();
+      if (networkInfo == null || !networkInfo.isConnected()) {
+        connectionType = CONNECTION_TYPE_NONE;
+      } else {
+        int networkType = networkInfo.getType();
+        switch (networkType) {
+          case ConnectivityManager.TYPE_BLUETOOTH:
+            connectionType = CONNECTION_TYPE_BLUETOOTH;
+            break;
+          case ConnectivityManager.TYPE_ETHERNET:
+            connectionType = CONNECTION_TYPE_ETHERNET;
+            break;
+          case ConnectivityManager.TYPE_MOBILE:
+          case ConnectivityManager.TYPE_MOBILE_DUN:
+            connectionType = CONNECTION_TYPE_CELLULAR;
+            effectiveConnectionType = getEffectiveConnectionType(networkInfo);
+            break;
+          case ConnectivityManager.TYPE_WIFI:
+            connectionType = CONNECTION_TYPE_WIFI;
+            break;
+          case ConnectivityManager.TYPE_WIMAX:
+            connectionType = CONNECTION_TYPE_WIMAX;
+            break;
+        }
+      }
+    } catch (SecurityException e) {
+      setNoNetworkPermission();
+      connectionType = CONNECTION_TYPE_UNKNOWN;
+    }
+
+    updateConnectivity(connectionType, effectiveConnectionType);
+  }
+
+  /**
+   * Class that receives intents whenever the connection type changes.
+   * NB: It is possible on some devices to receive certain connection type changes multiple times.
+   */
+  private class ConnectivityBroadcastReceiver extends BroadcastReceiver {
+
+    //TODO: Remove registered check when source of crash is found. t9846865
+    private boolean isRegistered = false;
+
+    public void setRegistered(boolean registered) {
+      isRegistered = registered;
+    }
+
+    public boolean isRegistered() {
+      return isRegistered;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      String action = intent.getAction();
+      if (action != null && action.equals(ConnectivityManager.CONNECTIVITY_ACTION)) {
+        updateAndSendConnectionType();
+      }
+    }
+  }
+}

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.reactnativecommunity.netinfo;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.support.v4.net.ConnectivityManagerCompat;
+import android.telephony.TelephonyManager;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+abstract class ConnectivityReceiver {
+  // Based on the ConnectionType enum described in the W3C Network Information API spec
+  // (https://wicg.github.io/netinfo/).
+  static final String CONNECTION_TYPE_BLUETOOTH = "bluetooth";
+  static final String CONNECTION_TYPE_CELLULAR = "cellular";
+  static final String CONNECTION_TYPE_ETHERNET = "ethernet";
+  static final String CONNECTION_TYPE_NONE = "none";
+  static final String CONNECTION_TYPE_UNKNOWN = "unknown";
+  static final String CONNECTION_TYPE_WIFI = "wifi";
+  static final String CONNECTION_TYPE_WIMAX = "wimax";
+
+  // Based on the EffectiveConnectionType enum described in the W3C Network Information API spec
+  // (https://wicg.github.io/netinfo/).
+  static final String EFFECTIVE_CONNECTION_TYPE_UNKNOWN = "unknown";
+  static final String EFFECTIVE_CONNECTION_TYPE_2G = "2g";
+  static final String EFFECTIVE_CONNECTION_TYPE_3G = "3g";
+  static final String EFFECTIVE_CONNECTION_TYPE_4G = "4g";
+
+
+  static final String MISSING_PERMISSION_MESSAGE =
+    "To use NetInfo on Android, add the following to your AndroidManifest.xml:\n" +
+      "<uses-permission android:name=\"android.permission.ACCESS_NETWORK_STATE\" />";
+
+  static final String ERROR_MISSING_PERMISSION = "E_MISSING_PERMISSION";
+
+  private final ConnectivityManager mConnectivityManager;
+  private final ReactApplicationContext mReactContext;
+
+  private boolean mNoNetworkPermission = false;
+  private String mConnectionType = CONNECTION_TYPE_UNKNOWN;
+  private String mEffectiveConnectionType = EFFECTIVE_CONNECTION_TYPE_UNKNOWN;
+
+  ConnectivityReceiver(ReactApplicationContext reactContext) {
+    mReactContext = reactContext;
+    mConnectivityManager =
+      (ConnectivityManager) reactContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+  }
+
+  abstract void register();
+  abstract void unregister();
+
+  public void getCurrentConnectivity(Promise promise) {
+    if (mNoNetworkPermission) {
+      promise.reject(ERROR_MISSING_PERMISSION, MISSING_PERMISSION_MESSAGE);
+      return;
+    }
+    promise.resolve(createConnectivityEventMap());
+  }
+
+  @SuppressLint("MissingPermission")
+  public void isConnectionMetered(Promise promise) {
+    if (mNoNetworkPermission) {
+      promise.reject(ERROR_MISSING_PERMISSION, MISSING_PERMISSION_MESSAGE);
+      return;
+    }
+    promise.resolve(ConnectivityManagerCompat.isActiveNetworkMetered(getConnectivityManager()));
+  }
+
+  public ReactApplicationContext getReactContext() {
+    return mReactContext;
+  }
+
+  public ConnectivityManager getConnectivityManager() {
+    return mConnectivityManager;
+  }
+
+  public void setNoNetworkPermission() {
+    mNoNetworkPermission = true;
+  }
+
+  String getEffectiveConnectionType(NetworkInfo networkInfo) {
+    switch (networkInfo.getSubtype()) {
+      case TelephonyManager.NETWORK_TYPE_1xRTT:
+      case TelephonyManager.NETWORK_TYPE_CDMA:
+      case TelephonyManager.NETWORK_TYPE_EDGE:
+      case TelephonyManager.NETWORK_TYPE_GPRS:
+      case TelephonyManager.NETWORK_TYPE_IDEN:
+        return EFFECTIVE_CONNECTION_TYPE_2G;
+      case TelephonyManager.NETWORK_TYPE_EHRPD:
+      case TelephonyManager.NETWORK_TYPE_EVDO_0:
+      case TelephonyManager.NETWORK_TYPE_EVDO_A:
+      case TelephonyManager.NETWORK_TYPE_EVDO_B:
+      case TelephonyManager.NETWORK_TYPE_HSDPA:
+      case TelephonyManager.NETWORK_TYPE_HSPA:
+      case TelephonyManager.NETWORK_TYPE_HSUPA:
+      case TelephonyManager.NETWORK_TYPE_UMTS:
+        return EFFECTIVE_CONNECTION_TYPE_3G;
+      case TelephonyManager.NETWORK_TYPE_HSPAP:
+      case TelephonyManager.NETWORK_TYPE_LTE:
+        return EFFECTIVE_CONNECTION_TYPE_4G;
+      case TelephonyManager.NETWORK_TYPE_UNKNOWN:
+      default:
+        return EFFECTIVE_CONNECTION_TYPE_UNKNOWN;
+    }
+  }
+
+  void updateConnectivity(String connectionType, String effectiveConnectionType) {
+    // It is possible to get multiple broadcasts for the same connectivity change, so we only
+    // update and send an event when the connectivity has indeed changed.
+    if (!connectionType.equalsIgnoreCase(mConnectionType) ||
+      !effectiveConnectionType.equalsIgnoreCase(mEffectiveConnectionType)) {
+      mConnectionType = connectionType;
+      mEffectiveConnectionType = effectiveConnectionType;
+      sendConnectivityChangedEvent();
+    }
+  }
+
+  private void sendConnectivityChangedEvent() {
+    getReactContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+      .emit("networkStatusDidChange", createConnectivityEventMap());
+  }
+
+  private WritableMap createConnectivityEventMap() {
+    WritableMap event = new WritableNativeMap();
+    event.putString("connectionType", mConnectionType);
+    event.putString("effectiveConnectionType", mEffectiveConnectionType);
+    return event;
+  }
+}

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -7,79 +7,40 @@
 
 package com.reactnativecommunity.netinfo;
 
-import android.annotation.SuppressLint;
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.support.v4.net.ConnectivityManagerCompat;
-import android.telephony.TelephonyManager;
+import android.os.Build;
 
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.WritableNativeMap;
-
-import static com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
 /**
  * Module that monitors and provides information about the connectivity state of the device.
  */
-@SuppressLint("MissingPermission")
-public class NetInfoModule extends ReactContextBaseJavaModule
-    implements LifecycleEventListener {
-
-  // Based on the ConnectionType enum described in the W3C Network Information API spec
-  // (https://wicg.github.io/netinfo/).
-  private static final String CONNECTION_TYPE_BLUETOOTH = "bluetooth";
-  private static final String CONNECTION_TYPE_CELLULAR = "cellular";
-  private static final String CONNECTION_TYPE_ETHERNET = "ethernet";
-  private static final String CONNECTION_TYPE_NONE = "none";
-  private static final String CONNECTION_TYPE_UNKNOWN = "unknown";
-  private static final String CONNECTION_TYPE_WIFI = "wifi";
-  private static final String CONNECTION_TYPE_WIMAX = "wimax";
-
-  // Based on the EffectiveConnectionType enum described in the W3C Network Information API spec
-  // (https://wicg.github.io/netinfo/).
-  private static final String EFFECTIVE_CONNECTION_TYPE_UNKNOWN = "unknown";
-  private static final String EFFECTIVE_CONNECTION_TYPE_2G = "2g";
-  private static final String EFFECTIVE_CONNECTION_TYPE_3G = "3g";
-  private static final String EFFECTIVE_CONNECTION_TYPE_4G = "4g";
-
-  private static final String MISSING_PERMISSION_MESSAGE =
-      "To use NetInfo on Android, add the following to your AndroidManifest.xml:\n" +
-      "<uses-permission android:name=\"android.permission.ACCESS_NETWORK_STATE\" />";
-
-  private static final String ERROR_MISSING_PERMISSION = "E_MISSING_PERMISSION";
+public class NetInfoModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
   public static final String NAME = "RNCNetInfo";
 
-  private final ConnectivityManager mConnectivityManager;
-  private final ConnectivityBroadcastReceiver mConnectivityBroadcastReceiver;
-  private boolean mNoNetworkPermission = false;
-
-  private String mConnectionType = CONNECTION_TYPE_UNKNOWN;
-  private String mEffectiveConnectionType = EFFECTIVE_CONNECTION_TYPE_UNKNOWN;
+  private final ConnectivityReceiver mConnectivityReceiver;
 
   public NetInfoModule(ReactApplicationContext reactContext) {
     super(reactContext);
-    mConnectivityManager =
-        (ConnectivityManager) reactContext.getSystemService(Context.CONNECTIVITY_SERVICE);
-    mConnectivityBroadcastReceiver = new ConnectivityBroadcastReceiver();
+    // Create the connectivity receiver based on the API level we are running on
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      mConnectivityReceiver = new NetworkCallbackConnectivityReceiver(reactContext);
+    } else {
+      mConnectivityReceiver = new BroadcastReceiverConnectivityReceiver(reactContext);
+    }
   }
 
   @Override
   public void onHostResume() {
-    registerReceiver();
+    mConnectivityReceiver.register();
   }
 
   @Override
   public void onHostPause() {
-    unregisterReceiver();
+    mConnectivityReceiver.unregister();
   }
 
   @Override
@@ -98,148 +59,11 @@ public class NetInfoModule extends ReactContextBaseJavaModule
 
   @ReactMethod
   public void getCurrentConnectivity(Promise promise) {
-    if (mNoNetworkPermission) {
-      promise.reject(ERROR_MISSING_PERMISSION, MISSING_PERMISSION_MESSAGE);
-      return;
-    }
-    promise.resolve(createConnectivityEventMap());
+    mConnectivityReceiver.getCurrentConnectivity(promise);
   }
 
   @ReactMethod
   public void isConnectionMetered(Promise promise) {
-    if (mNoNetworkPermission) {
-      promise.reject(ERROR_MISSING_PERMISSION, MISSING_PERMISSION_MESSAGE);
-      return;
-    }
-    promise.resolve(ConnectivityManagerCompat.isActiveNetworkMetered(mConnectivityManager));
-  }
-
-  @SuppressWarnings("deprecation")
-  private void registerReceiver() {
-    IntentFilter filter = new IntentFilter();
-    filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
-    getReactApplicationContext().registerReceiver(mConnectivityBroadcastReceiver, filter);
-    mConnectivityBroadcastReceiver.setRegistered(true);
-    updateAndSendConnectionType();
-  }
-
-  private void unregisterReceiver() {
-    if (mConnectivityBroadcastReceiver.isRegistered()) {
-      getReactApplicationContext().unregisterReceiver(mConnectivityBroadcastReceiver);
-      mConnectivityBroadcastReceiver.setRegistered(false);
-    }
-  }
-
-  @SuppressWarnings("deprecation")
-  private void updateAndSendConnectionType() {
-    String connectionType = CONNECTION_TYPE_UNKNOWN;
-    String effectiveConnectionType = EFFECTIVE_CONNECTION_TYPE_UNKNOWN;
-
-    try {
-      NetworkInfo networkInfo = mConnectivityManager.getActiveNetworkInfo();
-      if (networkInfo == null || !networkInfo.isConnected()) {
-        connectionType = CONNECTION_TYPE_NONE;
-      } else {
-        int networkType = networkInfo.getType();
-        switch (networkType) {
-          case ConnectivityManager.TYPE_BLUETOOTH:
-            connectionType = CONNECTION_TYPE_BLUETOOTH;
-            break;
-          case ConnectivityManager.TYPE_ETHERNET:
-            connectionType = CONNECTION_TYPE_ETHERNET;
-            break;
-          case ConnectivityManager.TYPE_MOBILE:
-          case ConnectivityManager.TYPE_MOBILE_DUN:
-            connectionType = CONNECTION_TYPE_CELLULAR;
-            effectiveConnectionType = getEffectiveConnectionType(networkInfo);
-            break;
-          case ConnectivityManager.TYPE_WIFI:
-            connectionType = CONNECTION_TYPE_WIFI;
-            break;
-          case ConnectivityManager.TYPE_WIMAX:
-            connectionType = CONNECTION_TYPE_WIMAX;
-            break;
-          default:
-            connectionType = CONNECTION_TYPE_UNKNOWN;
-            break;
-        }
-      }
-    } catch (SecurityException e) {
-      mNoNetworkPermission = true;
-      connectionType = CONNECTION_TYPE_UNKNOWN;
-    }
-
-    // It is possible to get multiple broadcasts for the same connectivity change, so we only
-    // update and send an event when the connectivity has indeed changed.
-    if (!connectionType.equalsIgnoreCase(mConnectionType) ||
-        !effectiveConnectionType.equalsIgnoreCase(mEffectiveConnectionType)) {
-      mConnectionType = connectionType;
-      mEffectiveConnectionType = effectiveConnectionType;
-      sendConnectivityChangedEvent();
-    }
-  }
-
-  private String getEffectiveConnectionType(NetworkInfo networkInfo) {
-    switch (networkInfo.getSubtype()) {
-      case TelephonyManager.NETWORK_TYPE_1xRTT:
-      case TelephonyManager.NETWORK_TYPE_CDMA:
-      case TelephonyManager.NETWORK_TYPE_EDGE:
-      case TelephonyManager.NETWORK_TYPE_GPRS:
-      case TelephonyManager.NETWORK_TYPE_IDEN:
-        return EFFECTIVE_CONNECTION_TYPE_2G;
-      case TelephonyManager.NETWORK_TYPE_EHRPD:
-      case TelephonyManager.NETWORK_TYPE_EVDO_0:
-      case TelephonyManager.NETWORK_TYPE_EVDO_A:
-      case TelephonyManager.NETWORK_TYPE_EVDO_B:
-      case TelephonyManager.NETWORK_TYPE_HSDPA:
-      case TelephonyManager.NETWORK_TYPE_HSPA:
-      case TelephonyManager.NETWORK_TYPE_HSUPA:
-      case TelephonyManager.NETWORK_TYPE_UMTS:
-        return EFFECTIVE_CONNECTION_TYPE_3G;
-      case TelephonyManager.NETWORK_TYPE_HSPAP:
-      case TelephonyManager.NETWORK_TYPE_LTE:
-        return EFFECTIVE_CONNECTION_TYPE_4G;
-      case TelephonyManager.NETWORK_TYPE_UNKNOWN:
-      default:
-        return EFFECTIVE_CONNECTION_TYPE_UNKNOWN;
-    }
-  }
-
-  private void sendConnectivityChangedEvent() {
-    getReactApplicationContext().getJSModule(RCTDeviceEventEmitter.class)
-        .emit("networkStatusDidChange", createConnectivityEventMap());
-  }
-
-  private WritableMap createConnectivityEventMap() {
-    WritableMap event = new WritableNativeMap();
-    event.putString("connectionType", mConnectionType);
-    event.putString("effectiveConnectionType", mEffectiveConnectionType);
-    return event;
-  }
-
-  /**
-   * Class that receives intents whenever the connection type changes.
-   * NB: It is possible on some devices to receive certain connection type changes multiple times.
-   */
-  private class ConnectivityBroadcastReceiver extends BroadcastReceiver {
-
-    //TODO: Remove registered check when source of crash is found. t9846865
-    private boolean isRegistered = false;
-
-    public void setRegistered(boolean registered) {
-      isRegistered = registered;
-    }
-
-    public boolean isRegistered() {
-      return isRegistered;
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public void onReceive(Context context, Intent intent) {
-      if (intent.getAction().equals(ConnectivityManager.CONNECTIVITY_ACTION)) {
-        updateAndSendConnectionType();
-      }
-    }
+    mConnectivityReceiver.isConnectionMetered(promise);
   }
 }

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.reactnativecommunity.netinfo;
+
+import android.annotation.SuppressLint;
+import android.net.ConnectivityManager;
+import android.net.LinkProperties;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+
+/**
+ * This gets the connectivity status using a NetworkCallback on the system default network. This
+ * method was added into Android from API level 24 (N) and we use it for all devices which support
+ * it.
+ */
+class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
+  private final ConnectivityNetworkCallback mNetworkCallback;
+  private Network mNetwork = null;
+  private NetworkCapabilities mNetworkCapabilities = null;
+
+  public NetworkCallbackConnectivityReceiver(ReactApplicationContext reactContext) {
+    super(reactContext);
+    mNetworkCallback = new ConnectivityNetworkCallback();
+  }
+
+  @Override
+  @SuppressLint("MissingPermission")
+  void register() {
+    try {
+      getConnectivityManager().registerDefaultNetworkCallback(mNetworkCallback);
+    } catch (SecurityException e) {
+      setNoNetworkPermission();
+    }
+  }
+
+  @Override
+  void unregister() {
+    try {
+      getConnectivityManager().unregisterNetworkCallback(mNetworkCallback);
+    } catch (SecurityException e) {
+      setNoNetworkPermission();
+    }
+  }
+
+  @SuppressLint("MissingPermission")
+  private void updateAndSend() {
+    String connectionType = CONNECTION_TYPE_UNKNOWN;
+    String effectiveConnectionType = EFFECTIVE_CONNECTION_TYPE_UNKNOWN;
+
+    if (mNetworkCapabilities != null) {
+      if (mNetworkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
+        connectionType = CONNECTION_TYPE_BLUETOOTH;
+      } else if (mNetworkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+        connectionType = CONNECTION_TYPE_CELLULAR;
+
+        if (mNetwork != null) {
+          NetworkInfo networkInfo = getConnectivityManager().getNetworkInfo(mNetwork);
+          effectiveConnectionType = getEffectiveConnectionType(networkInfo);
+        }
+      } else if (mNetworkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+        connectionType = CONNECTION_TYPE_ETHERNET;
+      } else if (mNetworkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+        connectionType = CONNECTION_TYPE_WIFI;
+      }
+    }
+
+    updateConnectivity(connectionType, effectiveConnectionType);
+  }
+
+  private class ConnectivityNetworkCallback extends ConnectivityManager.NetworkCallback {
+    @Override
+    public void onAvailable(Network network) {
+      mNetwork = network;
+      updateAndSend();
+    }
+
+    @Override
+    public void onLosing(Network network, int maxMsToLive) {
+      mNetwork = network;
+      updateAndSend();
+    }
+
+    @Override
+    public void onLost(Network network) {
+      mNetwork = null;
+      mNetworkCapabilities = null;
+      updateAndSend();
+    }
+
+    @Override
+    public void onUnavailable() {
+      mNetwork = null;
+      mNetworkCapabilities = null;
+      updateAndSend();
+    }
+
+    @Override
+    public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
+      mNetwork = network;
+      mNetworkCapabilities = networkCapabilities;
+      updateAndSend();
+    }
+
+    @Override
+    public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
+      mNetwork = network;
+      updateAndSend();
+    }
+  }
+}


### PR DESCRIPTION
*Migrated from https://github.com/facebook/react-native/pull/22981*

This PR changes NetInfo to use the newer and better supported [NetworkCallback](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback) on API levels 24 and above.

This is in place of the now deprecated BroadcastReceiver method. Both are kept so we can continue supporting down to API level 16. This is done by splitting out the connectivity code into two different classes, organised around a base abstract class to avoid duplication. Which class to use is chosen at runtime with a simple `if` statement in the NetInfo module.

The structure of the `connectionChange` event has not been changed, so this will be a non-breaking change for most users. The slight exception to that is that I have now removed the [previously deprecated](https://github.com/facebook/react-native/commit/fc38fe1736080215e3c462e25081d530a5399dc3) code from the module to avoid needing to support it in the new NetworkCllback code, however, this should be a non-issue as it was deprecated 2 years ago and doesn't even feature in the documentation anymore.

There is a slight difference in behaviour, which is down to a limitation in the old broadcast receiver method of updating the connectivity status. If the device changes from one cellular network type to another (effective network type), for example from 2g to 4g, this previously didn't trigger a new event. Using the new Network Callback method, it does.

Test Plan:
----------

* Open the RNTester app to the `NetInfoExample` screen.
* Toggle the Wifi on and off.
* Change the network type in the emulator (changing from LTE to GPRS for example).
* See that the events are fired and have the correct status in the RNTester screen.
* Do this for devices above and below the API level 24 threshold to ensure it works the same on both (aside from the limitation on changes to the effective network type for devices below API level 24, see above).

Gif of it working on Android: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/97068/51110838-dcc58480-17f1-11e9-9843-134395acf403.gif)

