### PR TITLE
Flow & TypeScript Typings

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -17,28 +17,20 @@ const NetInfoEventEmitter = new NativeEventEmitter(RNCNetInfo);
 
 const DEVICE_CONNECTIVITY_EVENT = 'networkStatusDidChange';
 
-type ChangeEventName = $Enum<{
-  connectionChange: string,
-}>;
+type ChangeEventName = 'connectionChange';
 
-type ConnectionType = $Enum<{
+export type ConnectionType =
   // iOS & Android
-  cell: 'cellular',
-  none: 'none',
-  unknown: 'unknown',
-  wifi: 'wifi',
+  | 'none'
+  | 'cellular'
+  | 'unknown'
+  | 'wifi'
   // Android only
-  bluetooth: 'bluetooth',
-  ethernet: 'ethernet',
-  wimax: 'wimax',
-}>;
+  | 'bluetooth'
+  | 'ethernet'
+  | 'wimax';
 
-type EffectiveConnectionType = $Enum<{
-  unknown: 'unknown',
-  '2g': '2g',
-  '3g': '3g',
-  '4g': '4g',
-}>;
+export type EffectiveConnectionType = 'unknown' | '2g' | '3g' | '4g';
 
 type ChangeHandler = ({
   type: ConnectionType,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "React Native Network Info API for iOS & Android",
   "main": "js/index.js",
+  "typings": "typings/index.d.ts",
   "author": "Matt Oakes <hello@mattoakes.net>",
   "contributors": [],
   "homepage": "https://github.com/react-native-community/react-native-netinfo#readme",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+type ChangeEventName = 'connectionChange';
+
+export type ConnectionType =
+  // iOS & Android
+  | 'none'
+  | 'cellular'
+  | 'unknown'
+  | 'wifi'
+  // Android only
+  | 'bluetooth'
+  | 'ethernet'
+  | 'wimax';
+
+export type EffectiveConnectionType = 'unknown' | '2g' | '3g' | '4g';
+
+export interface ConnectionInfo {
+  type: ConnectionType;
+  effectiveType: EffectiveConnectionType;
+}
+
+export interface NetInfoStatic {
+  /**
+   * This function is deprecated. Use `getConnectionInfo` instead. Returns a promise that
+   * resolves with one of the deprecated connectivity types listed above.
+   */
+  fetch: () => Promise<ConnectionType>;
+
+  /**
+   * Adds an event handler. Supported events:
+   *
+   * - `connectionChange`: Fires when the network status changes. The argument to the event
+   *   handler is an object with keys:
+   *   - `type`: A `DeprecatedConnectionType` (listed above)
+   *   - `effectiveType`: An `EffectiveConnectionType` (listed above)
+   */
+  addEventListener: (
+    eventName: ChangeEventName,
+    listener: (result: ConnectionInfo) => void,
+  ) => void;
+
+  /**
+   * Removes the listener for network status changes.
+   */
+  removeEventListener: (
+    eventName: ChangeEventName,
+    listener: (result: ConnectionInfo) => void,
+  ) => void;
+
+  /**
+   * Returns a promise that resolves to an object with `type` and `effectiveType` keys
+   * whose values are a `ConnectionType` and an `EffectiveConnectionType`, (described above),
+   * respectively.
+   */
+  getConnectionInfo: () => Promise<ConnectionInfo>;
+
+  /**
+   * An object with the same methods as above but the listener receives a
+   * boolean which represents the internet connectivity.
+   * Use this if you are only interested with whether the device has internet
+   * connectivity.
+   */
+  isConnected: {
+    fetch: () => Promise<boolean>,
+
+    /**
+     * eventName is expected to be `change`(deprecated) or `connectionChange`
+     */
+    addEventListener: (
+      eventName: ChangeEventName,
+      listener: (result: boolean) => void,
+    ) => void,
+
+    /**
+     * eventName is expected to be `change`(deprecated) or `connectionChange`
+     */
+    removeEventListener: (
+      eventName: ChangeEventName,
+      listener: (result: boolean) => void,
+    ) => void,
+  };
+
+  /**
+   * Detect if the current active connection is
+   * metered or not. A network is classified as metered when the user is
+   * sensitive to heavy data usage on that connection due to monetary
+   * costs, data limitations or battery/performance issues.
+   */
+  isConnectionExpensive: () => Promise<boolean>;
+}


### PR DESCRIPTION
I have simplified the Flow types to remove the use of `$Enum`, which is undocumented in the Flow documentation and replaced them with simple type definitions. This also removed the confusion over if it's `cell` or `cellular` as the enum used different values for the key and value (It turns out that the `@types/react-native` types are actually wrong and it's `cellular`).

I have also added TypeScript typings to the repository which should make it seamless to get type support for either language.