### PR TITLE
Add Detox end-to-end testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ android_defaults: &android_defaults
   <<: *defaults
   docker:
   - image: circleci/android:api-27-node8-alpha
-  resource_class: "large"
   environment:
   - TERM: "dumb"
   - ADB_INSTALL_TIMEOUT: 10
@@ -30,7 +29,6 @@ android_defaults: &android_defaults
 # MACOS
 macos_defaults: &macos_defaults
   <<: *defaults
-  resource_class: "large"
   macos:
     xcode: "10.1.0"
 
@@ -58,11 +56,35 @@ aliases:
   - ~/.gradle
   key: gradle-cache-{{ checksum "android/build.gradle" }}-{{ checksum "example/android/build.gradle" }}-{{ checksum "example/android/app/build.gradle" }}
 
+- &restore-macos-gradle-cache
+  keys:
+  - macos-gradle-cache-{{ checksum "android/build.gradle" }}-{{ checksum "example/android/build.gradle" }}-{{ checksum "example/android/app/build.gradle" }}
+- &save-macos-gradle-cache
+  paths:
+  - ~/.gradle
+  key: macos-gradle-cache-{{ checksum "android/build.gradle" }}-{{ checksum "example/android/build.gradle" }}-{{ checksum "example/android/app/build.gradle" }}
+
+- &restore-homebrew-cache
+  keys:
+  - homebrew-cache-v1
+- &save-homebrew-cache
+  paths:
+  - ~/Library/Caches/Homebrew
+  - /usr/local/Homebrew
+  key: homebrew-cache-v1
+
+- &restore-ios-detox-cache
+  keys:
+  - ios-detox-cache-v1
+- &save-ios-detox-cache
+  paths:
+  - ~/react-native-netinfo/example/ios/build
+  key: ios-detox-cache-v1
+
 # INSTALLATION
 - &yarn
   name: Yarn Install
-  command: |
-    yarn install --network-concurrency 1 --non-interactive --cache-folder ~/.cache/yarn & wait
+  command: yarn install --network-concurrency 1 --non-interactive --cache-folder ~/.cache/yarn & wait
 
 # ANALYSE
 - &eslint
@@ -76,6 +98,15 @@ aliases:
 - &jest
   name: Jest Unit Tests
   command: yarn test:jest
+
+- &metro
+  name: Start React Native Packager (background)
+  background: true
+  command: yarn start || true
+- &metro-warmup
+  name: Warm up Packager
+  background: true
+  command: node .circleci/scripts/packager-warmup.js
 
 # -------------------------
 #          JOBS
@@ -116,7 +147,7 @@ jobs:
     - attach_workspace:
         at: ~/react-native-netinfo
     - run: *jest
-  
+
   android-compile:
     <<: *android_defaults
     steps:
@@ -135,7 +166,89 @@ jobs:
           ./gradlew clean assembleDebug
     - save-cache: *save-gradle-cache
   
-  ios-checkout:
+  android-detox:
+    <<: *macos_defaults
+    steps:
+    # Setup
+    - checkout
+    - run:
+        name: Configure Environment Variables
+        command: |
+          echo 'export PATH="$PATH:/usr/local/opt/node@8/bin:~/.yarn/bin:~/react-native-firebase/node_modules/.bin:~/react-native-firebase/tests/node_modules/.bin"' >> $BASH_ENV
+          echo 'export ANDROID_HOME="/usr/local/share/android-sdk"' >> $BASH_ENV
+          echo 'export ANDROID_SDK_ROOT="/usr/local/share/android-sdk"' >> $BASH_ENV
+          echo 'export PATH="$ANDROID_SDK_ROOT/emulator:$ANDROID_SDK_ROOT/tools:$ANDROID_SDK_ROOT/platform-tools:$PATH"' >> $BASH_ENV
+          echo 'export QEMU_AUDIO_DRV=none' >> $BASH_ENV
+          echo 'export JAVA_HOME=/Library/Java/Home' >> $BASH_ENV
+          source $BASH_ENV
+    
+    - restore-cache: *restore-homebrew-cache
+    - run:
+        name: Install Android SDK Tools
+        command: |
+          HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask >/dev/null
+          HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk >/dev/null
+          HOMEBREW_NO_AUTO_UPDATE=1 brew cask install intel-haxm >/dev/null
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install node@8 >/dev/null >/dev/null
+    - save-cache: *save-homebrew-cache
+
+    - restore-cache: *restore-yarn-cache
+    - run: rm -rf node_modules
+    - run: *yarn
+    - save-cache: *save-yarn-cache
+
+    - restore-cache: *restore-macos-gradle-cache
+    - run:
+        name: Accept Android licences
+        command: |-
+          yes | sdkmanager --licenses || exit 0
+          yes | sdkmanager --update || exit 0
+    - run:
+        name: Build app using Detox
+        command: yarn test:detox:android:build
+    - save-cache: *save-macos-gradle-cache
+
+    - run: *metro
+    - run: *metro-warmup
+
+    - run:
+        name: Install Android Emulator
+        shell: /bin/bash -e
+        command: |
+          yes | sdkmanager "platform-tools"  "tools" >/dev/null
+          yes | sdkmanager "platforms;android-28" "system-images;android-27;google_apis;x86" "system-images;android-28;google_apis;x86" >/dev/null
+          yes | sdkmanager "emulator" --channel=3 >/dev/null
+          yes | sdkmanager "build-tools;28.0.3" >/dev/null
+          yes | sdkmanager --licenses >/dev/null
+          yes | sdkmanager --list
+    # to force ssh key generation for emulators
+    - run:
+        name: ADB Start Stop
+        command: |
+          adb start-server
+          adb devices
+          adb kill-server
+          ls -la ~/.android
+    
+    - run:
+        name: Create Android Emulator (API 28)
+        command: avdmanager create avd --force -n TestingAVD -k "system-images;android-28;google_apis;x86" -g google_apis -d "Nexus 4"
+    - run:
+        name: Start Android Emulator (API 28) in background
+        command: |
+          /usr/local/share/android-sdk/emulator/emulator @TestingAVD -version
+          /usr/local/share/android-sdk/emulator/emulator @TestingAVD -skin 470x860 -cores 2 -gpu auto -accel on -memory 2048 -no-audio -no-snapshot -no-window -logcat *:W | grep -i 'ReactNative\|RNFB\|com.testing\|io.invertase\|firebase'
+        background: true
+    - run:
+        name: Wait for AVD to be ready (API 28)
+        no_output_timeout: "5m"
+        command: sh ./.circleci/scripts/wait-for-avd.sh
+
+    - run:
+        name: Run detox tests
+        command: yarn test:detox:android:test
+
+  ios-detox:
     <<: *macos_defaults
     steps:
     - checkout
@@ -144,19 +257,29 @@ jobs:
     - run: yarn cache clean
     - run: *yarn
     - save-cache: *save-yarn-cache
-    - persist_to_workspace:
-        root: .
-        paths: .
-
-  ios-compile:
-    <<: *macos_defaults
-    steps:
-    - attach_workspace:
-        at: ~/react-native-netinfo
+    - restore-cache: *restore-homebrew-cache
     - run:
-        name: Build example app
+        name: Install AppleSimUtils
         command: |-
-          react-native run-ios --project-path example/ios
+          brew tap wix/brew
+          brew install applesimutils
+    - save-cache: *save-homebrew-cache
+    - run:
+        name: Install React Native CLI
+        command: npm install -g react-native-cli
+    - run:
+        name: Install Detox CLI
+        command: npm install -g detox-cli
+    - run: *metro
+    - run: *metro-warmup
+    - restore-cache: *restore-ios-detox-cache
+    - run: 
+        name: Build app using Detox
+        command: yarn test:detox:ios:build
+    - save-cache: *save-ios-detox-cache
+    - run: 
+        name: Run detox tests
+        command: yarn test:detox:ios:test
 
   publish:
     <<: *linux_defaults
@@ -187,11 +310,8 @@ workflows:
     - android-compile:
         requires:
         - linux-checkout
-# Disabled until we have macOS containers enabled        
-#     - ios-checkout
-#     - ios-compile:
-#         requires:
-#         - ios-checkout
+    - android-detox
+    - ios-detox
     - publish:
         requires:
         - linux-checkout
@@ -199,6 +319,8 @@ workflows:
         - flow
         - jest
         - android-compile
+        - android-detox
+        - ios-detox
         filters:
           branches:
             only: master

--- a/.circleci/scripts/packager-warmup.js
+++ b/.circleci/scripts/packager-warmup.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const axios = require('axios');
+const { sleep, getReactNativePlatform, A2A } = require('./utils');
+
+let waitAttempts = 1;
+let maxWaitAttempts = 60;
+
+async function waitForPackager() {
+  let ready = false;
+
+  while (waitAttempts < maxWaitAttempts) {
+    console.log(`Waiting for packager to be ready, attempt ${waitAttempts} of ${maxWaitAttempts}...`);
+    const [error, response] = await A2A(axios.get('http://localhost:8081/status', { timeout: 500 }));
+    // metro bundler only
+    if (error && error.response && error.response.data && error.response.data.includes('Cannot GET /status')) {
+      ready = true;
+      break;
+    }
+
+    // rn-cli only
+    if (!error && response.data.includes('packager-status:running')) {
+      ready = true;
+      break;
+    }
+
+    await sleep(1500);
+    waitAttempts++;
+  }
+
+  if (!ready) {
+    return Promise.reject(new Error('Packager failed to be ready.'));
+  }
+
+  console.log('Packager is now ready!');
+
+  return true;
+}
+
+(async function main() {
+  const [packagerError] = await A2A(waitForPackager());
+  if (packagerError) {
+    console.error(packagerError);
+    process.exitCode = 1;
+    process.exit();
+  }
+
+  const platform = getReactNativePlatform();
+  const map = `http://localhost:8081/example/index.map?platform=${platform}&dev=true&minify=false&inlineSourceMap=true`;
+  const bundle = `http://localhost:8081/example/index.bundle?platform=${platform}&dev=true&minify=false&inlineSourceMap=true`;
+
+  console.log(`Requesting ${platform} bundle...`);
+  console.log(bundle);
+  const [bundleError] = await A2A(axios.get(bundle));
+  if (bundleError) {
+    console.error(bundleError);
+    process.exitCode = 1;
+    process.exit();
+  }
+
+  console.log(`Requesting ${platform} bundle source map...`);
+  console.log(map);
+  const [bundleMapError] = await A2A(axios.get(map));
+  if (bundleMapError) {
+    console.error(bundleMapError);
+    process.exitCode = 1;
+    process.exit();
+  }
+
+  console.log('Warm-up complete!')
+})();

--- a/.circleci/scripts/utils.js
+++ b/.circleci/scripts/utils.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * "sleep" for the specified time in milliseconds - returns a promise
+ *
+ * @param duration milliseconds
+ * @return {Promise<any> | Promise}
+ */
+module.exports.sleep = function sleep(duration) {
+  return new Promise(resolve => setTimeout(resolve, duration));
+};
+
+/**
+ * Get the current react native platform based on current test job with
+ * a fallback to process.platform
+ *
+ * @return {string}
+ */
+module.exports.getReactNativePlatform = function getReactNativePlatform() {
+  if (process.env.CIRCLE_JOB) {
+    if (process.env.CIRCLE_JOB.includes('android')) {
+      return 'android';
+    }
+    if (process.env.CIRCLE_JOB.includes('ios')) {
+      return 'ios';
+    }
+  }
+
+  if (process.platform.includes('darwin')) {
+    return 'ios';
+  }
+
+  return 'android';
+};
+
+/**
+ * Async/Await to Array [error, result]
+ *
+ * Examples:
+ *
+ *    // 0 - standard usage
+ *
+ *        const [dbError, dbResult] = await A2A(TodoModel.find({ id: 1 }));
+ *
+ *    // 1) if an error isn't needed:
+ *
+ *        const [ , dbResult ] = await A2A(TodoModel.find({ id: 1 }));
+ *        // if (!dbResult) return somethingSomethingHandleResult();
+ *
+ *    // 2) if a result isn't needed:
+ *
+ *        const [ dbError ] = await A2A(TodoModel.destroy({ id: 1 }));
+ *        if (dbError) return somethingSomethingHandleError();
+ *
+ *    // 3) if neither error or result are needed:
+ *
+ *        await A2A(TodoModel.destroy({ id: 1 }));
+ *
+ *    // 4) multiple promises
+ *
+ *        const promises = [];
+ *
+ *        promises.push(Promise.resolve(1));
+ *        promises.push(Promise.resolve(2));
+ *        promises.push(Promise.resolve(3));
+ *
+ *        const [ , results ] = await A2A(promises);
+ *
+ *    // 5) non promise values
+ *
+ *        const [ error, nothingHere ] = await A2A(new Error('Just a foo in a bar world'));
+ *        if (error) profit(); // ?
+ *
+ *        const [ nothingHere, myThing ] = await A2A('A thing string');
+ *
+ *
+ * @param oOrP Object or Primitive
+ * @returns {*} Promise<Array>
+ * @constructor
+ */
+module.exports.A2A = function A2A(oOrP) {
+  if (!oOrP) return Promise.resolve([null, oOrP]);
+
+  // single promise
+  if (oOrP.then) {
+    return oOrP.then((r) => [null, r]).catch((e) => [e, undefined]);
+  }
+
+  // function that returns a single promise
+  if (typeof oOrP === 'function') {
+    return oOrP()
+    .then((r) => [null, r])
+    .catch((e) => [e, undefined]);
+  }
+
+  // array of promises
+  if (Array.isArray(oOrP) && oOrP.length && oOrP[0].then) {
+    return Promise.all(oOrP)
+    .then((r) => [null, r])
+    .catch((e) => [e, undefined]);
+  }
+
+  // array of functions that returns a single promise
+  if (Array.isArray(oOrP) && oOrP.length && typeof oOrP[0] === 'function') {
+    return Promise.all(oOrP.map((f) => f()))
+    .then((r) => [null, r])
+    .catch((e) => [e, undefined]);
+  }
+
+  // non promise values - error
+  if (oOrP instanceof Error) return Promise.resolve([oOrP, undefined]);
+
+  // non promise values - any other value
+  return Promise.resolve([null, oOrP]);
+};

--- a/.circleci/scripts/wait-for-avd.sh
+++ b/.circleci/scripts/wait-for-avd.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright (c) 2016-present Invertase Limited & Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this library except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+bootanim=""
+
+echo "Waiting for AVD to finish booting"
+export PATH=$(dirname $(dirname $(command -v android)))/platform-tools:$PATH
+
+until [[ "$bootanim" =~ "stopped" ]]; do
+  sleep 10
+  bootanim=$(adb -e shell getprop init.svc.bootanim 2>&1)
+done
+
+# extra time to let the OS settle
+sleep 25
+
+echo "Android Virtual Device is now ready."

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -103,6 +103,9 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+        testBuildType System.getProperty('testBuildType', 'debug')
+        missingDimensionStrategy "minReactNative", "minReactNative46"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     splits {
         abi {
@@ -138,6 +141,11 @@ dependencies {
     implementation project(':react-native-netinfo')
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
+
+    androidTestImplementation(project(path: ":detox"))
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/example/android/app/src/androidTest/java/com/reactnativecommunity/netinfo/example/DetoxTest.java
+++ b/example/android/app/src/androidTest/java/com/reactnativecommunity/netinfo/example/DetoxTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.reactnativecommunity.netinfo.example;
+
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.wix.detox.Detox;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class DetoxTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
+
+    @Test
+    public void runDetoxTests() throws InterruptedException {
+        Detox.runTests(mActivityRule);
+    }
+}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,10 +3,13 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 18
         compileSdkVersion = 28
         targetSdkVersion = 27
         supportLibVersion = "28.0.0"
+
+        // e2e
+        kotlinVersion = '1.3.0'
     }
     repositories {
         google()
@@ -14,6 +17,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -28,14 +32,6 @@ allprojects {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../../node_modules/react-native/android"
-        }
-    }
-
-    // Turn on all lint warnings and report them as errors
-    // This only affects the example project and not library users. We use this to catch warnings early
-    gradle.projectsEvaluated {
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:all" << "-Werror"
         }
     }
 }

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -5,4 +5,8 @@ project(':react-native-netinfo').projectDir = new File(rootProject.projectDir, '
 // For your application the line above will most likely be:
 // project(':react-native-netinfo').projectDir = new File(rootProject.projectDir, '../node_modules/!react-native-community/netinfo/android')
 
+// e2e tests
+include ':detox'
+project(':detox').projectDir = new File(rootProject.projectDir, '../../node_modules/detox/android/detox')
+
 include ':app'

--- a/example/e2e/config.json
+++ b/example/e2e/config.json
@@ -1,0 +1,4 @@
+{
+  "setupFilesAfterEnv": ["./init.js"],
+  "testEnvironment": "node"
+}

--- a/example/e2e/init.js
+++ b/example/e2e/init.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+/* eslint-env jest, jasmine */
+
+const detox = require('detox');
+const config = require('../../package.json').detox;
+const adapter = require('detox/runners/jest/adapter');
+
+jest.setTimeout(120000);
+jasmine.getEnv().addReporter(adapter);
+
+beforeAll(async () => {
+  await detox.init(config);
+});
+
+beforeEach(async () => {
+  await adapter.beforeEach();
+});
+
+afterAll(async () => {
+  await adapter.afterAll();
+  await detox.cleanup();
+});

--- a/example/e2e/sanityTest.spec.js
+++ b/example/e2e/sanityTest.spec.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+/* eslint-env jest */
+/* global device, element, by */
+
+describe('NetInfo', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+  });
+
+  it('should load example app with no errors and show all the examples', async () => {
+    await expect(element(by.id('examples'))).toExist();
+    await expect(element(by.id('example-isConnected'))).toExist();
+    await expect(element(by.id('example-currentInfoSingle'))).toExist();
+    await expect(element(by.id('example-currentInfoHistory'))).toExist();
+    await expect(element(by.id('example-isConnectionExpensive'))).toExist();
+  });
+});

--- a/example/index.js
+++ b/example/index.js
@@ -26,6 +26,7 @@ import {name as appName} from './app.json';
 
 const EXAMPLES = [
   {
+    id: 'isConnected',
     title: 'NetInfo.isConnected',
     description: 'Asynchronously load and observe connectivity',
     render() {
@@ -33,20 +34,23 @@ const EXAMPLES = [
     },
   },
   {
-    title: 'NetInfo.update',
+    id: 'currentInfoSingle',
+    title: 'Current Info Single',
     description: 'Asynchronously load and observe connectionInfo',
     render() {
       return <ConnectionInfoCurrent />;
     },
   },
   {
-    title: 'NetInfo.updateHistory',
+    id: 'currentInfoHistory',
+    title: 'Current Info History',
     description: 'Observed updates to connectionInfo',
     render() {
       return <ConnectionInfoSubscription />;
     },
   },
   {
+    id: 'isConnectionExpensive',
     title: 'NetInfo.isConnectionExpensive (Android)',
     description: 'Asynchronously check isConnectionExpensive',
     render() {
@@ -58,10 +62,13 @@ const EXAMPLES = [
 class ExampleApp extends React.Component<{}> {
   render() {
     return (
-      <ScrollView style={styles.container}>
+      <ScrollView testID="examples" style={styles.container}>
         <SafeAreaView>
           {EXAMPLES.map(example => (
-            <View key={example.title} style={styles.exampleContainer}>
+            <View
+              testID={`example-${example.id}`}
+              key={example.title}
+              style={styles.exampleContainer}>
               <Text style={styles.exampleTitle}>{example.title}</Text>
               <Text style={styles.exampleDescription}>
                 {example.description}

--- a/js/__tests__/eventListenerCallbacks.js
+++ b/js/__tests__/eventListenerCallbacks.js
@@ -9,7 +9,6 @@
  */
 /* eslint-env jest */
 
-import {NativeModules} from 'react-native';
 import NetInfo from '../index';
 import {NetInfoEventEmitter} from '../nativeInterface';
 

--- a/js/__tests__/eventListenerManagement.js
+++ b/js/__tests__/eventListenerManagement.js
@@ -11,7 +11,6 @@
 
 import {NativeModules} from 'react-native';
 import NetInfo from '../index';
-import {NetInfoEventEmitter} from '../nativeInterface';
 
 describe('react-native-netinfo', () => {
   describe('Event listener management', () => {

--- a/js/__tests__/isConnectionExpensiveIOS.js
+++ b/js/__tests__/isConnectionExpensiveIOS.js
@@ -16,7 +16,6 @@ jest.mock('Platform', () => {
 });
 
 import NetInfo from '../index';
-import {RNCNetInfo} from '../nativeInterface';
 
 describe('react-native-netinfo', () => {
   describe('isConnectionExpensive', () => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "test": "yarn test:eslint && yarn test:flow && yarn test:jest",
     "test:eslint": "eslint 'js/**/*.js' 'example/**/*.js'",
     "test:flow": "flow check",
-    "test:jest": "jest",
+    "test:jest": "jest js/",
+    "test:detox:android:build": "detox build -c android.emu.debug",
+    "test:detox:android:test": "detox test -c android.emu.debug",
+    "test:detox:ios:build": "detox build -c ios.sim.debug",
+    "test:detox:ios:test": "detox test -c ios.sim.debug",
     "ci:publish": "yarn semantic-release",
     "semantic-release": "semantic-release"
   },
@@ -32,10 +36,12 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@semantic-release/git": "7.0.5",
+    "axios": "^0.18.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.1.0",
     "babel-plugin-module-resolver": "^3.1.3",
+    "detox": "^10.0.7",
     "eslint": "5.13.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-flowtype": "3.2.1",
@@ -58,6 +64,24 @@
     "setupFilesAfterEnv": [
       "<rootDir>/jest.setup.js"
     ]
+  },
+  "detox": {
+    "test-runner": "jest",
+    "runner-config": "example/e2e/config.json",
+    "configurations": {
+      "ios.sim.debug": {
+        "binaryPath": "example/ios/build/Build/Products/Debug-iphonesimulator/NetInfoExample.app",
+        "build": "xcodebuild -project example/ios/NetInfoExample.xcodeproj -scheme NetInfoExample -configuration Debug -sdk iphonesimulator -derivedDataPath example/ios/build  -UseModernBuildSystem=NO",
+        "type": "ios.simulator",
+        "name": "iPhone X"
+      },
+      "android.emu.debug": {
+        "binaryPath": "example/android/app/build/outputs/apk/debug/app-debug.apk",
+        "build": "cd example/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ../..",
+        "type": "android.emulator",
+        "name": "TestingAVD"
+      }
+    }
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,6 +1193,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
@@ -1361,7 +1369,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3:
+bluebird@3.5.x, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
   integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
@@ -1474,6 +1482,24 @@ builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
+bunyan-debug-stream@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bunyan-debug-stream/-/bunyan-debug-stream-1.1.1.tgz#4740a00b7d5c2d9d1b714925ab0802516040813e"
+  integrity sha512-jJbQ1gXUL6vMmZVdbaTFK1v1sGa7axLrSQQwkB6HU9HCPTzsw2HsKcPHm1vgXZlEck/4IvEuRwg/9+083YelCg==
+  dependencies:
+    colors "^1.0.3"
+    exception-formatter "^1.0.4"
+
+bunyan@^1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
+  integrity sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.10.6"
+    mv "~2"
+    safe-json-stringify "~1"
 
 byline@^5.0.0:
   version "5.0.0"
@@ -1652,6 +1678,15 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+child-process-promise@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-2.2.1.tgz#4730a11ef610fad450b8f223c79d31d7bdad8074"
+  integrity sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=
+  dependencies:
+    cross-spawn "^4.0.2"
+    node-version "^1.0.0"
+    promise-polyfill "^6.0.1"
+
 chownr@^1.0.1, chownr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
@@ -1817,7 +1852,7 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2:
+colors@^1.0.3, colors@^1.1.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
@@ -1837,7 +1872,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.9.0:
+commander@^2.15.1, commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -2055,6 +2090,14 @@ create-react-class@^15.6.3:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-spawn@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2139,7 +2182,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2153,7 +2196,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -2274,6 +2317,28 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detox@^10.0.7:
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-10.0.7.tgz#559e0239ae10a1bada24426608c02cb32a73e15d"
+  integrity sha512-oHunX6M+5qy01Sy+o0MGInOkFpROKFfDXU7Z9aUywlXSjNxCUHFUc4J/mgJdFYTogA2W3Md+Mt4kc89+nwqztQ==
+  dependencies:
+    bunyan "^1.8.12"
+    bunyan-debug-stream "^1.1.0"
+    child-process-promise "^2.2.0"
+    commander "^2.15.1"
+    fs-extra "^4.0.2"
+    get-port "^2.1.0"
+    ini "^1.3.4"
+    lodash "^4.17.5"
+    minimist "^1.2.0"
+    proper-lockfile "^3.0.2"
+    sanitize-filename "^1.6.1"
+    shell-utils "^1.0.9"
+    tail "^1.2.3"
+    telnet-client "0.15.3"
+    tempfile "^2.0.0"
+    ws "^1.1.1"
+
 dezalgo@^1.0.0, dezalgo@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
@@ -2339,6 +2404,13 @@ dotenv@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
+
+dtrace-provider@~0.8:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
+  integrity sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=
+  dependencies:
+    nan "^2.10.0"
 
 duplexer2@~0.1.0:
   version "0.1.4"
@@ -2676,6 +2748,13 @@ eventemitter3@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
+
+exception-formatter@^1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/exception-formatter/-/exception-formatter-1.0.7.tgz#3291616b86fceabefa97aee6a4708032c6e3b96d"
+  integrity sha512-zV45vEsjytJrwfGq6X9qd1Ll56cW4NC2mhCO6lqwMk4ZpA1fZ6C3UiaQM/X7if+7wZFmCgss3ahp9B/uVFuLRw==
+  dependencies:
+    colors "^1.0.3"
 
 exec-sh@^0.2.0:
   version "0.2.2"
@@ -3073,6 +3152,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@^1.3.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
+  dependencies:
+    debug "^3.2.6"
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3135,6 +3221,15 @@ fs-extra@^1.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
+
+fs-extra@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^7.0.0:
   version "7.0.1"
@@ -3253,6 +3348,13 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-port@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-2.1.0.tgz#8783f9dcebd1eea495a334e1a6a251e78887ab1a"
+  integrity sha1-h4P53OvR7qSVozThpqJR54iHqxo=
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -3331,6 +3433,17 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
@@ -3661,7 +3774,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4886,11 +4999,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4899,32 +5007,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -4976,11 +5062,6 @@ lodash.padstart@^4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
   integrity sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=
 
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
-
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
@@ -5021,7 +5102,7 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.x.x, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -5538,7 +5619,7 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -5635,6 +5716,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment@^2.10.6:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 morgan@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -5678,7 +5764,16 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.9.2:
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.10.0, nan@^2.9.2:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
   integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
@@ -5704,6 +5799,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 needle@^2.2.1:
   version "2.2.4"
@@ -5812,6 +5912,11 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-version@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.2.0.tgz#34fde3ffa8e1149bd323983479dda620e1b5060d"
+  integrity sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -6602,6 +6707,18 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
 pirates@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.0.tgz#850b18781b4ac6ec58a43c9ed9ec5fe6796addbd"
@@ -6745,6 +6862,11 @@ promise-inflight@^1.0.1, promise-inflight@~1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise-polyfill@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
+  integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
+
 promise-retry@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
@@ -6782,6 +6904,15 @@ prop-types@^15.5.8, prop-types@^15.6.2:
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+proper-lockfile@^3.0.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-3.2.0.tgz#89ca420eea1d55d38ca552578851460067bcda66"
+  integrity sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==
+  dependencies:
+    graceful-fs "^4.1.11"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -7158,7 +7289,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
@@ -7419,6 +7550,13 @@ rimraf@~2.2.6:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
   integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
+  dependencies:
+    glob "^6.0.1"
+
 rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
@@ -7462,6 +7600,11 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -7490,6 +7633,13 @@ sane@^3.0.0:
     watch "~0.18.0"
   optionalDependencies:
     fsevents "^1.2.3"
+
+sanitize-filename@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a"
+  integrity sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
 
 sax@^1.2.4:
   version "1.2.4"
@@ -7662,6 +7812,13 @@ shell-quote@1.6.1, shell-quote@^1.6.1:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
+
+shell-utils@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/shell-utils/-/shell-utils-1.0.10.tgz#7fe7b8084f5d6d21323d941267013bc38aed063e"
+  integrity sha512-p1xuqhj3jgcXiV8wGoF1eL/NOvapN9tyGDoObqKwvZTUZn7fIzK75swLTEHfGa7sObeN9vxFplHw/zgYUYRTsg==
+  dependencies:
+    lodash "4.x.x"
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -8146,6 +8303,11 @@ table@^5.0.2:
     slice-ansi "^2.0.0"
     string-width "^2.1.1"
 
+tail@^1.2.3:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/tail/-/tail-1.4.0.tgz#884b216220b90804bfe87a4c8174c2efed0e2661"
+  integrity sha512-wjwfZw6wcMFTB1Po7NFUf4TdCDwX8duZjdTMhnHBEC677Q6mFRcVZE7f/nZDhG2Fpf/wEEKOJP9L7/b11/vlHQ==
+
 tar@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -8168,6 +8330,18 @@ tar@^4, tar@^4.4.3, tar@^4.4.8:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+telnet-client@0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/telnet-client/-/telnet-client-0.15.3.tgz#99ec754e4acf6fa51dc69898f574df3c2550712e"
+  integrity sha512-GSfdzQV0BKIYsmeXq7bJFJ2wHeJud6icaIxCUf6QCGQUD6R0BBGbT1+yLDhq67JRdgRpwyPwUbV7JxFeRrZomQ==
+  dependencies:
+    bluebird "3.5.x"
+
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+  integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
+
 temp@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
@@ -8175,6 +8349,14 @@ temp@0.8.3:
   dependencies:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
+
+tempfile@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-2.0.0.tgz#6b0446856a9b1114d1856ffcbe509cccb0977265"
+  integrity sha1-awRGhWqbERTRhW/8vlCczLCXcmU=
+  dependencies:
+    temp-dir "^1.0.0"
+    uuid "^3.0.1"
 
 term-size@^1.2.0:
   version "1.2.0"
@@ -8329,6 +8511,13 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
+  dependencies:
+    utf8-byte-length "^1.0.1"
 
 tslib@^1.9.0:
   version "1.9.3"
@@ -8534,6 +8723,11 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -8557,7 +8751,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -8757,7 +8951,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^1.1.0, ws@^1.1.5:
+ws@^1.1.0, ws@^1.1.1, ws@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51"
   integrity sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==


### PR DESCRIPTION
This adds the foundations for E2E testing for the library using [Detox](https://github.com/wix/Detox). It runs on CircleCI on macOS containers.

Note that I have pulled in 3 utility files from `react-native-firebase` which are licenced under Apache. I have kept their original copyright notice, however, I'm not certain what the policy is with mixing them in this way.