### PR TITLE
fix(iOS): Ensure all calls to isConnected.fetch resolve

### DIFF
--- a/example/e2e/sanityTest.spec.js
+++ b/example/e2e/sanityTest.spec.js
@@ -14,11 +14,24 @@ describe('NetInfo', () => {
     await device.reloadReactNative();
   });
 
-  it('should load example app with no errors and show all the examples', async () => {
-    await expect(element(by.id('examples'))).toExist();
+  it('should load example app with no errors and show all the examples by default', async () => {
+    await expect(element(by.id('examplesTitle'))).toExist();
     await expect(element(by.id('example-isConnected'))).toExist();
     await expect(element(by.id('example-currentInfoSingle'))).toExist();
     await expect(element(by.id('example-currentInfoHistory'))).toExist();
     await expect(element(by.id('example-isConnectionExpensive'))).toExist();
+  });
+
+  it('should show the test cases when the button is toggled', async () => {
+    await element(by.id('modeToggle')).tap();
+
+    await expect(element(by.id('testCasesTitle'))).toExist();
+  });
+
+  it('should show the examples again when the button is toggled twice', async () => {
+    await element(by.id('modeToggle')).tap();
+    await element(by.id('modeToggle')).tap();
+
+    await expect(element(by.id('examplesTitle'))).toExist();
   });
 });

--- a/example/e2e/testCases/multipleIsConnected.spec.js
+++ b/example/e2e/testCases/multipleIsConnected.spec.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+/* eslint-env jest */
+/* global device, element, by */
+
+const TEST_CASE_COUNT = 5;
+
+describe('NetInfo', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+    await element(by.id('modeToggle')).tap();
+  });
+
+  it('should have the correct elements to perform the test', async () => {
+    await expect(element(by.id('multipleIsConnectedResults'))).toExist();
+    await expect(element(by.id('multipleIsConnectedTestButton'))).toExist();
+  });
+
+  const testAllResultsAre = async value => {
+    for (let i = 0; i < TEST_CASE_COUNT; i++) {
+      await expect(element(by.id(`multipleIsConnectedResult${i}`))).toHaveLabel(
+        value,
+      );
+    }
+  };
+
+  it('should start with all failures', async () => {
+    await testAllResultsAre('fail');
+  });
+
+  it('should show all success after being tested', async () => {
+    await element(by.id('multipleIsConnectedTestButton')).tap();
+    await testAllResultsAre('pass');
+  });
+});

--- a/example/index.js
+++ b/example/index.js
@@ -11,6 +11,7 @@
 import React from 'react';
 import {
   AppRegistry,
+  Button,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -24,6 +25,7 @@ import IsConnected from './IsConnected';
 import IsConnectionExpensive from './IsConnectionExpensive';
 import {name as appName} from './app.json';
 
+// Examples which show the user how to correctly use the library
 const EXAMPLES = [
   {
     id: 'isConnected',
@@ -59,29 +61,68 @@ const EXAMPLES = [
   },
 ];
 
-class ExampleApp extends React.Component<{}> {
+// Test cases for the e2e tests. THESE ARE NOT EXAMPLES OF BEST PRACTICE
+import TEST_CASES from './testCases';
+
+type State = {
+  showExamples: boolean,
+};
+
+class ExampleApp extends React.Component<{}, State> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showExamples: true,
+    };
+  }
+
+  _toggleMode = () => {
+    this.setState(state => ({showExamples: !state.showExamples}));
+  };
+
   render() {
+    const {showExamples} = this.state;
     return (
-      <ScrollView testID="examples" style={styles.container}>
+      <ScrollView style={styles.container}>
         <SafeAreaView>
-          {EXAMPLES.map(example => (
-            <View
-              testID={`example-${example.id}`}
-              key={example.title}
-              style={styles.exampleContainer}>
-              <Text style={styles.exampleTitle}>{example.title}</Text>
-              <Text style={styles.exampleDescription}>
-                {example.description}
+          <Button
+            testID="modeToggle"
+            onPress={this._toggleMode}
+            title={showExamples ? 'Switch to Test Cases' : 'Switch to Examples'}
+          />
+          {showExamples ? (
+            <>
+              <Text testID="examplesTitle" style={styles.sectionTitle}>
+                Examples
               </Text>
-              <View style={styles.exampleInnerContainer}>
-                {example.render()}
-              </View>
-            </View>
-          ))}
+              {EXAMPLES.map(this._renderExample)}
+            </>
+          ) : (
+            <>
+              <Text testID="testCasesTitle" style={styles.sectionTitle}>
+                Test Cases
+              </Text>
+              {TEST_CASES.map(this._renderExample)}
+            </>
+          )}
         </SafeAreaView>
       </ScrollView>
     );
   }
+
+  _renderExample = example => {
+    return (
+      <View
+        testID={`example-${example.id}`}
+        key={example.title}
+        style={styles.exampleContainer}>
+        <Text style={styles.exampleTitle}>{example.title}</Text>
+        <Text style={styles.exampleDescription}>{example.description}</Text>
+        <View style={styles.exampleInnerContainer}>{example.render()}</View>
+      </View>
+    );
+  };
 }
 
 const styles = StyleSheet.create({
@@ -89,9 +130,14 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#F5FCFF',
   },
+  sectionTitle: {
+    fontSize: 24,
+    marginHorizontal: 8,
+    marginTop: 24,
+  },
   exampleContainer: {
     padding: 16,
-    marginVertical: 16,
+    marginVertical: 4,
     backgroundColor: '#FFF',
     borderColor: '#EEE',
     borderTopWidth: 1,

--- a/example/testCases/MultipleIsConnected.js
+++ b/example/testCases/MultipleIsConnected.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import React, {Component} from 'react';
+import {Button, Text, View} from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
+
+type State = {
+  results: boolean[],
+};
+
+const TEST_CASE_COUNT = 5;
+
+export default class MultipleIsConnected extends Component<{}, State> {
+  constructor(props: {}) {
+    super(props);
+
+    let results = [];
+    for (let i = 0; i < TEST_CASE_COUNT; i++) {
+      results.push(false);
+    }
+
+    this.state = {results};
+  }
+
+  _onPress = () => {
+    for (let i = 0; i < TEST_CASE_COUNT; i++) {
+      NetInfo.isConnected.fetch().then(isConnected => {
+        this.setState(state => {
+          const results = state.results.map((result, index) =>
+            index === i ? true : result,
+          );
+          return {results};
+        });
+      });
+    }
+  };
+
+  render() {
+    return (
+      <View>
+        <Button
+          testID="multipleIsConnectedTestButton"
+          onPress={this._onPress}
+          title="Reproduce 🕷"
+        />
+        <View
+          testID="multipleIsConnectedResults"
+          style={{flexDirection: 'row'}}>
+          {this.state.results.map((result, index) => (
+            <Text
+              key={index}
+              testID={`multipleIsConnectedResult${index}`}
+              accessibilityLabel={result ? 'pass' : 'fail'}>
+              {result ? '✅' : '❌'}
+            </Text>
+          ))}
+        </View>
+      </View>
+    );
+  }
+}

--- a/example/testCases/index.js
+++ b/example/testCases/index.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import React from 'react';
+
+import MultipleIsConnected from './MultipleIsConnected';
+
+export default [
+  {
+    id: 'multipleIsConnected',
+    title: 'NetInfo.isConnected.fetch Multiple Calls',
+    description: 'Should resolve all promises when calling multiple times',
+    render() {
+      return <MultipleIsConnected />;
+    },
+  },
+];

--- a/ios/RNCNetInfo.xcodeproj/project.pbxproj
+++ b/ios/RNCNetInfo.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNCNetInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNCNetInfo.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RNCNetInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCNetInfo.h; sourceTree = "<group>"; };
-		B3E7B5891CC2AC0600A0062D /* RNCNetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCNetInfo.m; sourceTree = "<group>"; };
+		B3E7B5891CC2AC0600A0062D /* RNCNetInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = RNCNetInfo.m; sourceTree = "<group>"; tabWidth = 2; };
 		C923EDBB220C2C1A00D3100F /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 


### PR DESCRIPTION
This fixes the issue where multiple calls to `isConnected.fetch` would only resolve the final one on iOS. It would correctly resolve them on Android.

The fix was was keep a copy of all of the resolvers, not just the last one, in an NSSet. We can then call them all when the connection data comes back.

I have also added an e2e test case to test this behaviour. We need to wait for #14 to be merged in before this is ready to do. I'm opening a fancy new "draft" PR now so it's here.

Fixes #10.