### PR TITLE
feat(linking): Add Cocoapods Podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,24 @@ You then need to link the native parts of the library for the platforms you are 
 react-native link @react-native-community/netinfo
 ```
 
-If you can't or don't want to use the CLI tool, you can also manually link the library on iOS using the [intructions in the React Native documentation](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking). On Android you can make the following changes to link the library (click on the arrow to show them):
+If you can't or don't want to use the CLI tool, you can also manually link the library using the instructions below (click on the arrow to show them):
+
+<details>
+<summary>Manually link the library on iOS</summary>
+
+Either follow the [intructions in the React Native documentation](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking) to manually link the framework or link using [Cocoapods](https://cocoapods.org) by adding this to your `Podfile`:
+
+```ruby
+pod 'react-native-netinfo', path: '../node_modules/react-native-netinfo'
+```
+
+</details>
 
 <details>
 <summary>Manually link the library on Android</summary>
-   
+
+Make the following changes:
+
 #### `android/settings.gradle`
 ```groovy
 include ':@react-native-community/netinfo'

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you can't or don't want to use the CLI tool, you can also manually link the l
 <details>
 <summary>Manually link the library on iOS</summary>
 
-Either follow the [intructions in the React Native documentation](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking) to manually link the framework or link using [Cocoapods](https://cocoapods.org) by adding this to your `Podfile`:
+Either follow the [instructions in the React Native documentation](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking) to manually link the framework or link using [Cocoapods](https://cocoapods.org) by adding this to your `Podfile`:
 
 ```ruby
 pod 'react-native-netinfo', path: '../node_modules/react-native-netinfo'

--- a/react-native-netinfo.podspec
+++ b/react-native-netinfo.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
Adds the podspec which is is required to use the library with Cocoapods. I have also added the instructions to the README.