### PR TITLE
fix(podspec): remove slash from "name" and add missing ":tag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you can't or don't want to use the CLI tool, you can also manually link the l
 Either follow the [instructions in the React Native documentation](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking) to manually link the framework or link using [Cocoapods](https://cocoapods.org) by adding this to your `Podfile`:
 
 ```ruby
-pod 'react-native-netinfo', path: '../node_modules/react-native-netinfo'
+pod 'react-native-netinfo', :path => '../node_modules/@react-native-community/netinfo'
 ```
 
 </details>

--- a/react-native-netinfo.podspec
+++ b/react-native-netinfo.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = package['name']
+  s.name         = "react-native-netinfo"
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git", :tag => "#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
# Overview
![NetInfo errors](https://i.imgur.com/e8WRDf1.png)

In order to fix the error and the warn above, this PR:

1. changes `s.name` from `@react-native-community/netinfo` to `react-native-netinfo`
2. adds a `:tag` to `s.source`


# Test Plan

Install `react-native-netinfo` on iOS using CocoaPods 😅