### PR TITLE
fix(typing): Correctly export the methods for TypeScript

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -96,3 +96,6 @@ export interface NetInfoStatic {
    */
   isConnectionExpensive: () => Promise<boolean>;
 }
+
+declare let NetInfo: NetInfoStatic;
+export default NetInfo;


### PR DESCRIPTION
# Overview
This PR fixes TypeScript support by correctly exporting the methods as the default export.

# Test Plan
Use the library in a TypeScript file and see that the types work correctly.

Before:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/97068/53251630-01e0c900-36b5-11e9-8c32-f0d4b6c82541.png">

After:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/97068/53251586-ebd30880-36b4-11e9-9c76-91e6a78503b8.png">
