### PR TITLE
test(android): Ensure the release verison of the app has the Javascript correctly bundled

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -74,9 +74,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "example/index.js",
-    nodeExecutableAndArgs: ["echo", "'Skipping bundling"],
-    root: "../../../",
-    bundleInRelease: false
+    root: "../../../"
 ]
 
 apply from: "../../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
# Overview
The Android tests were failing on CircleCI. This looks to be an actual issue with the tests when running in release mode. The Javascript bundle was not being created correctly in the release APK. This PR should fix the issue and the ones in #23.

# Test Plan
CircleCI tests should pass.

Closes: #26 