### PR TITLE
Throw an error if the native module is null with steps to help fix the issue

### DIFF
--- a/js/nativeInterface.js
+++ b/js/nativeInterface.js
@@ -12,6 +12,17 @@ import {NativeEventEmitter, NativeModules} from 'react-native';
 
 const {RNCNetInfo} = NativeModules;
 
+// Produce an error if we don't have the native module
+if (!RNCNetInfo) {
+  throw new Error(`@react-native-community/netinfo: NativeModule.RNCNetInfo is null. To fix this issue try these steps:
+
+• Run \`react-native link @react-native-community/netinfo\` in the project root.
+• Rebuild and re-run the app.
+• If you are using CocoaPods on iOS, run \`pod install\` in the \`ios\` directory and then rebuild and re-run the app. You may also need to re-open Xcode to get the new pods.
+
+If none of these fix the issue, please open an issue on the Github repository: https://github.com/react-native-community/react-native-netinfo`);
+}
+
 /**
  * We export the native interface in this way to give easy shared access to it between the
  * JavaScript code and the tests


### PR DESCRIPTION
# Overview
Shows a helpful error message if linking has not been done correctly and the native module is null. It gives the steps that are most likely to fix the issue.

Before:

![image](https://user-images.githubusercontent.com/97068/54796382-43f61f80-4c0d-11e9-9a16-eca50b24006e.png)

After:

![image](https://user-images.githubusercontent.com/97068/54796302-ebbf1d80-4c0c-11e9-84f8-c6c74e87e6cd.png)

This will help to diagnose linking issues like #30.

# Test Plan
Delete `RNCNetInfo.a` from the "Linked Frameworks and Libraries" section and see the new error message.
