### PR TITLE
Change how event listeners work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rn: react-native-community/react-native@dev:0.1.0-rc10
+  rn: react-native-community/react-native@dev:0.1.0-rc12
 
 jobs:
   checkout_code:
@@ -66,6 +66,7 @@ workflows:
             - analyse
       - rn/android_test:
           detox_configuration: "android.emu.release"
+          detox_loglevel: "trace"
           requires:
             - build_android_release
       - rn/ios_build_and_test:
@@ -75,6 +76,7 @@ workflows:
           build_configuration: "Release"
           scheme: "NetInfoExample"
           detox_configuration: "ios.sim.release"
+          detox_loglevel: "trace"
           requires:
             - analyse
       - publish:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Cross platform values:
 * `unknown`
 
 ### Subscribe to connection info
-Subscribe to connection information. The callback is called whenever the connection status changes. The returned object shape is the same as `getConnectionInfo` above.
+Subscribe to connection information. The callback is called whenever the connection status changes. The returned object shape is the same as `getConnectionInfo` above. Your listener will be called with the latest information soon after you subscribe and then with any subsiquent changes afterwards. Due to platform differences, you should not assume that the listener is called in the same way across devices or platforms.
 
 ```javascript
 const listener = connectionInfo => {
@@ -180,6 +180,8 @@ subscription.remove();
 // Unsubscribe through event name
 NetInfo.isConnected.removeEventListener('connectionChange', listener);
 ```
+
+Your listener will be called with the latest information soon after you subscribe and then with any subsiquent changes afterwards. Due to platform differences, you should not assume that the listener is called in the same way across devices or platforms.
 
 ### Is connection expensive (Android only)
 Detect if the current active connection is metered or not. A network is classified as metered when the user is sensitive to heavy data usage on that connection due to monetary costs, data limitations or battery/performance issues.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -105,8 +105,7 @@ android {
         versionCode 1
         versionName "1.0"
         testBuildType System.getProperty('testBuildType', 'debug')
-        missingDimensionStrategy "minReactNative", "minReactNative46"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {
         release {
@@ -156,8 +155,6 @@ dependencies {
 
     androidTestImplementation(project(path: ":detox"))
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/example/android/app/src/androidTest/java/com/reactnativecommunity/netinfo/example/DetoxTest.java
+++ b/example/android/app/src/androidTest/java/com/reactnativecommunity/netinfo/example/DetoxTest.java
@@ -7,15 +7,15 @@
 
 package com.reactnativecommunity.netinfo.example;
 
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-
 import com.wix.detox.Detox;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
@@ -25,7 +25,7 @@ public class DetoxTest {
     public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
 
     @Test
-    public void runDetoxTests() throws InterruptedException {
+    public void runDetoxTests() {
         Detox.runTests(mActivityRule);
     }
 }

--- a/example/e2e/testCases/emitOnListen.spec.js
+++ b/example/e2e/testCases/emitOnListen.spec.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+/* eslint-env jest */
+/* global device, element, by */
+
+const TEST_CASE_COUNT = 5;
+
+describe('NetInfo', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+    await element(by.id('modeToggle')).tap();
+  });
+
+  it('should have the correct elements to perform the test', async () => {
+    await expect(element(by.id('emitOnListenResults'))).toExist();
+    await expect(element(by.id('emitOnListenTestButton'))).toExist();
+  });
+
+  it('should start with all failures', async () => {
+    await expect(element(by.id(`emitOnListenResult`))).toHaveLabel('fail');
+  });
+
+  it('should show all success after being tested', async () => {
+    await element(by.id('emitOnListenTestButton')).tap();
+    await expect(element(by.id(`emitOnListenResult`))).toHaveLabel('pass');
+  });
+});

--- a/example/testCases/EmitOnListen.js
+++ b/example/testCases/EmitOnListen.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+import React, {Component} from 'react';
+import {Button, Text, View} from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
+
+type State = {
+  triggered: boolean,
+};
+
+const TEST_CASE_COUNT = 5;
+
+export default class MultipleIsConnected extends Component<{}, State> {
+  constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      triggered: false,
+    };
+  }
+
+  _onPress = () => {
+    for (let i = 0; i < TEST_CASE_COUNT; i++) {
+      NetInfo.addEventListener(
+        'connectionChange',
+        this._handleConnectionChange,
+      );
+    }
+  };
+
+  _handleConnectionChange = info => {
+    this.setState({triggered: true});
+  };
+
+  render() {
+    const {triggered} = this.state;
+
+    return (
+      <View>
+        <Button
+          testID="emitOnListenTestButton"
+          onPress={this._onPress}
+          title="Reproduce 🕷"
+        />
+        <View testID="emitOnListenResults" style={{flexDirection: 'row'}}>
+          <Text
+            testID={`emitOnListenResult`}
+            accessibilityLabel={triggered ? 'pass' : 'fail'}>
+            Triggered: {triggered ? '✅' : '❌'}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+}

--- a/example/testCases/EmitOnListen.js
+++ b/example/testCases/EmitOnListen.js
@@ -27,13 +27,15 @@ export default class MultipleIsConnected extends Component<{}, State> {
     };
   }
 
+  componentWillUnmount() {
+    NetInfo.removeEventListener(
+      'connectionChange',
+      this._handleConnectionChange,
+    );
+  }
+
   _onPress = () => {
-    for (let i = 0; i < TEST_CASE_COUNT; i++) {
-      NetInfo.addEventListener(
-        'connectionChange',
-        this._handleConnectionChange,
-      );
-    }
+    NetInfo.addEventListener('connectionChange', this._handleConnectionChange);
   };
 
   _handleConnectionChange = info => {

--- a/example/testCases/EmitOnListen.js
+++ b/example/testCases/EmitOnListen.js
@@ -16,8 +16,6 @@ type State = {
   triggered: boolean,
 };
 
-const TEST_CASE_COUNT = 5;
-
 export default class MultipleIsConnected extends Component<{}, State> {
   constructor(props: {}) {
     super(props);

--- a/example/testCases/index.js
+++ b/example/testCases/index.js
@@ -10,9 +10,18 @@
 
 import React from 'react';
 
+import EmitOnListen from './EmitOnListen';
 import MultipleIsConnected from './MultipleIsConnected';
 
 export default [
+  {
+    id: 'emitOnListen',
+    title: 'NetInfo.addEventListener Emit on Listen',
+    description: 'Should emit when a new listener is added',
+    render() {
+      return <EmitOnListen />;
+    },
+  },
   {
     id: 'multipleIsConnected',
     title: 'NetInfo.isConnected.fetch Multiple Calls',

--- a/js/__tests__/eventListenerCallbacks.js
+++ b/js/__tests__/eventListenerCallbacks.js
@@ -10,10 +10,29 @@
 /* eslint-env jest */
 
 import NetInfo from '../index';
-import {NetInfoEventEmitter} from '../nativeInterface';
+import {RNCNetInfo, NetInfoEventEmitter} from '../nativeInterface';
 
 describe('react-native-netinfo', () => {
   describe('Event listener callbacks', () => {
+    beforeEach(() => {
+      NetInfo.clearEventListeners();
+
+      RNCNetInfo.getCurrentConnectivity.mockResolvedValue({
+        connectionType: 'cellular',
+        effectiveConnectionType: '3g',
+      });
+    });
+
+    it('should call the listener on listening', done => {
+      const listener = jest.fn();
+      NetInfo.addEventListener('connectionChange', listener);
+
+      setImmediate(() => {
+        expect(listener).toBeCalled();
+        done();
+      });
+    });
+
     it('should call the listener when the native event is emmitted', () => {
       const listener = jest.fn();
       NetInfo.addEventListener('connectionChange', listener);
@@ -45,7 +64,8 @@ describe('react-native-netinfo', () => {
         effectiveConnectionType: 'unknown',
       });
 
-      expect(listener).toBeCalledTimes(2);
+      // The additional time is from the call on listen
+      expect(listener).toBeCalledTimes(3);
     });
 
     it('should call all listeners when the native event is emmitted', () => {
@@ -76,6 +96,9 @@ describe('react-native-netinfo', () => {
       NetInfo.addEventListener('connectionChange', listener);
       NetInfo.removeEventListener('connectionChange', listener);
 
+      // Clear the stats from the call on listen
+      listener.mockClear();
+
       NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
         connectionType: 'cellular',
         effectiveConnectionType: '3g',
@@ -91,6 +114,9 @@ describe('react-native-netinfo', () => {
       NetInfo.addEventListener('connectionChange', listener2);
 
       NetInfo.removeEventListener('connectionChange', listener1);
+
+      // Clear the stats from the call on listen
+      listener1.mockClear();
 
       const expectedConnectionType = 'cellular';
       const expectedEffectiveConnectionType = '3g';

--- a/js/__tests__/eventListenerManagement.js
+++ b/js/__tests__/eventListenerManagement.js
@@ -14,6 +14,15 @@ import NetInfo from '../index';
 
 describe('react-native-netinfo', () => {
   describe('Event listener management', () => {
+    beforeEach(() => {
+      NetInfo.clearEventListeners();
+
+      NativeModules.RNCNetInfo.getCurrentConnectivity.mockResolvedValue({
+        connectionType: 'cellular',
+        effectiveConnectionType: '3g',
+      });
+    });
+
     it('should add the listener to the native module when passing the correct event name', () => {
       NetInfo.addEventListener('connectionChange', jest.fn());
       expect(NativeModules.RNCNetInfo.addListener).toBeCalledWith(

--- a/js/index.js
+++ b/js/index.js
@@ -130,9 +130,18 @@ const NetInfo = {
   },
 
   /**
+   * Removes all listeners.
+   */
+  clearEventListeners(): void {
+    for (let listener of _subscriptions) {
+      NetInfo.removeEventListener('connectionChange', listener);
+    }
+  },
+
+  /**
    * See https://facebook.github.io/react-native/docs/netinfo.html#getconnectioninfo
    */
-  getConnectionInfo(): Promise<any> {
+  getConnectionInfo(): Promise<NetInfoData> {
     return RNCNetInfo.getCurrentConnectivity().then(resp => {
       return {
         type: resp.connectionType,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.1.0",
     "babel-plugin-module-resolver": "^3.1.3",
-    "detox": "^10.0.7",
+    "detox": "^12.1.1",
     "eslint": "5.13.0",
     "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-flowtype": "3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,6 +942,11 @@ ansi-regex@^4.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
   integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
 
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -1864,7 +1869,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.15.1, commander@^2.9.0:
+commander@^2.9.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -2309,15 +2314,14 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
-detox@^10.0.7:
-  version "10.0.7"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-10.0.7.tgz#559e0239ae10a1bada24426608c02cb32a73e15d"
-  integrity sha512-oHunX6M+5qy01Sy+o0MGInOkFpROKFfDXU7Z9aUywlXSjNxCUHFUc4J/mgJdFYTogA2W3Md+Mt4kc89+nwqztQ==
+detox@^12.1.1:
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-12.1.1.tgz#98fd44ee003b4ed159cc6a3d68d34598e4ae26a9"
+  integrity sha512-QbZ9F+XD4UFsEIn4QTiObhiEXs1Tq5nvPt3UIG9123uAfp4WHFTVnCJomQliMwJu6flK4JP9fXYHfzwcccyFug==
   dependencies:
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"
     child-process-promise "^2.2.0"
-    commander "^2.15.1"
     fs-extra "^4.0.2"
     get-port "^2.1.0"
     ini "^1.3.4"
@@ -2330,6 +2334,8 @@ detox@^10.0.7:
     telnet-client "0.15.3"
     tempfile "^2.0.0"
     ws "^1.1.1"
+    yargs "^13.0.0"
+    yargs-parser "^13.0.0"
 
 dezalgo@^1.0.0, dezalgo@~1.0.3:
   version "1.0.3"
@@ -2443,6 +2449,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
@@ -3332,6 +3343,11 @@ get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-port@^2.1.0:
   version "2.1.0"
@@ -6389,7 +6405,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-locale@^3.0.0:
+os-locale@^3.0.0, os-locale@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
   integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
@@ -7461,6 +7477,11 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
@@ -8188,6 +8209,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -8225,6 +8255,13 @@ strip-ansi@^5.0.0:
   integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
   dependencies:
     ansi-regex "^4.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -9043,6 +9080,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.0.0.tgz#3fc44f3e76a8bdb1cc3602e860108602e5ccde8b"
+  integrity sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
@@ -9092,6 +9137,23 @@ yargs@^12.0.0, yargs@^12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^13.0.0:
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.2.2.tgz#0c101f580ae95cea7f39d927e7770e3fdc97f993"
+  integrity sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==
+  dependencies:
+    cliui "^4.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    os-locale "^3.1.0"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.0.0"
 
 yargs@^9.0.0:
   version "9.0.1"


### PR DESCRIPTION
# Overview
This PR changes the way that the library handles event subscriptions. Previously, each listener was hooked directly to the `DeviceEventEmitter` via a "handler" which transformed the shape of the returned object. This worked well, but exposed some platform differences as reported in #8.

This PR changes the system so the library will manage a single subscription to the `DeviceEventEmitter` and call all of the subscribed listeners when it reports changes. This also allows us to keep track of the latest information and call new listeners with it right away on both platforms. If the library has not yet received any information from the native code, it will request it and send it to the new listeners.

Even through this requires no code changes for users and they should not have been making assumptions about when the listener is called, I think this should be marked as a breaking change to be on the safe side.

# Test Plan
I have tested this manually, but I have also added an integration test case and Jest unit tests to verify the new behaviour.

Fixes #8.