### PR TITLE
[web] Add web support

### DIFF
--- a/js/nativeInterface.web.js
+++ b/js/nativeInterface.web.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Nicolas Gallagher.
+ * Copyright (c) Evan Bacon.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import findIndex from 'array-find-index';
+import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
+import invariant from 'fbjs/lib/invariant';
+
+
+// Map React Native events to browser equivalents
+const eventTypesMap = {
+    change: 'change',
+    connectionChange: 'change',
+};
+const eventTypes = Object.keys(eventTypesMap);
+
+const connectionListeners = [];
+const netInfoListeners = [];
+
+
+// Prevent the underlying event handlers from leaking and include additional
+// properties available in browsers
+// TODO: Bacon: Refactor the native values so we aren't doing this weird emulation.
+function getConnectionInfoObject() {
+  const connection = getConnection();
+  const result = {
+    connectionType: 'unknown',
+    effectiveConnectionType: 'unknown',
+  };
+  if (!connection) {
+    return result;
+  }
+  for (const prop in connection) {
+    const value = connection[prop];
+    if (typeof value !== 'function' && value != null) {
+      result[prop] = value;
+    }
+  }
+  return {
+    connectionType: result.type,
+    effectiveConnectionType: result.effectiveType,
+      ...result,
+    };
+}
+
+function getConnection() {
+// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/connection#Browser_compatibility
+    if (ExecutionEnvironment.canUseDOM) {
+        return (window.navigator.connection ||
+        window.navigator.mozConnection ||
+        window.navigator.webkitConnection);
+    }
+    return null;
+}
+
+/**
+ * We export the native interface in this way to give easy shared access to it between the
+ * JavaScript code and the tests
+ */
+export const RNCNetInfo = {
+    async getCurrentConnectivity(): Promise<any> {
+        return getConnectionInfoObject();
+    },
+    // TODO: Bacon: is `isConnectionMetered` supported?
+};
+
+export const NetInfoEventEmitter = {
+    addEventListener(type: string, handler: Function) {
+        if (type === 'networkStatusDidChange') {
+            const connection = getConnection();
+            if (!connection) {
+                console.error(
+                  'Network Connection API is not supported. Not listening for connection type changes.'
+                );
+                return {
+                  remove: () => {},
+                };
+            }
+            const wrappedHandler = () => handler(getConnectionInfoObject());
+            netInfoListeners.push([handler, wrappedHandler]);
+            connection.addEventListener(eventTypesMap[type], wrappedHandler);
+        } else {
+            const onlineCallback = () => handler(getConnectionInfoObject());
+            const offlineCallback = () => handler(getConnectionInfoObject());
+            connectionListeners.push([handler, onlineCallback, offlineCallback]);
+
+            window.addEventListener('online', onlineCallback, false);
+            window.addEventListener('offline', offlineCallback, false);
+        }
+
+        return {
+            remove() {
+                if (type === 'networkStatusDidChange') {
+                    const listenerIndex = findIndex(netInfoListeners, pair => pair[0] === handler);
+                    invariant(listenerIndex !== -1, 'Trying to remove NetInfo listener for unregistered handler');
+                    const [, wrappedHandler] = netInfoListeners[listenerIndex];
+                    const connection = getConnection();
+                    if (!connection) {
+                        throw new Error(
+                          'Network Connection API is not supported. Not listening for connection type changes.'
+                        );
+                    }
+                    connection.removeEventListener(eventTypesMap[type], wrappedHandler);
+                    netInfoListeners.splice(listenerIndex, 1);
+                    return;
+                }
+                invariant(
+                  eventTypes.indexOf(type) !== -1,
+                  'Trying to subscribe to unknown event: "%s"',
+                  type
+                );
+                if (type === 'change') {
+                  console.warn('Listening to event `change` is deprecated. Use `connectionChange` instead.');
+                }
+
+                const listenerIndex = findIndex(connectionListeners, pair => pair[0] === handler);
+                invariant(
+                  listenerIndex !== -1,
+                  'Trying to remove NetInfo connection listener for unregistered handler'
+                );
+                const [, onlineCallback, offlineCallback] = connectionListeners[listenerIndex];
+
+                window.removeEventListener('online', onlineCallback, false);
+                window.removeEventListener('offline', offlineCallback, false);
+
+                connectionListeners.splice(listenerIndex, 1);
+            },
+        };
+    },
+};

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "react": "^16.0",
     "react-native": ">=0.57 <0.60"
   },
-  "dependencies": {},
+  "dependencies": {
+    "array-find-index": "^1.0.2",
+    "fbjs": "^1.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.4.3",
     "@semantic-release/git": "7.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,7 +1361,7 @@ array-filter@~0.0.0:
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
   integrity sha1-fajPLiZijtcygDWB/SH2fKzS7uw=
 
-array-find-index@^1.0.1:
+array-find-index@^1.0.1, array-find-index@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Move **`NetInfo`** out of [`react-native-web`](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/NetInfo/index.js). 
Currently getting reports of users hitting errors when they use:

```js
import NetInfo from "@react-native-community/netinfo";
```

This is because the generic `react-native: "react-native-web"` alias is not accounting for the new library. We could add the alias to `@expo/webpack-config` but it may be simpler to just merge the two `NetInfo` modules.

CC: @necolas
Let me know if you wanna go another direction. I can also open a PR to remove the `NetInfo` module in RNWeb as well.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

TBD
