### PR TITLE
fix: Ensure Android network information is correct when the app returns from the background

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -18,7 +18,7 @@ import com.facebook.react.bridge.ReactMethod;
 /**
  * Module that monitors and provides information about the connectivity state of the device.
  */
-public class NetInfoModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
+public class NetInfoModule extends ReactContextBaseJavaModule {
   public static final String NAME = "RNCNetInfo";
 
   private final ConnectivityReceiver mConnectivityReceiver;
@@ -34,22 +34,13 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements Lifecyc
   }
 
   @Override
-  public void onHostResume() {
+  public void initialize() {
     mConnectivityReceiver.register();
   }
 
   @Override
-  public void onHostPause() {
+  public void onCatalystInstanceDestroy() {
     mConnectivityReceiver.unregister();
-  }
-
-  @Override
-  public void onHostDestroy() {
-  }
-
-  @Override
-  public void initialize() {
-    getReactApplicationContext().addLifecycleEventListener(this);
   }
 
   @Override


### PR DESCRIPTION
# Overview
This PR fixes #32.

It does this by ensuring the network information is kept up-to-date when the app goes into the background.

# Test Plan
Tested against https://github.com/matt-oakes/net-info-test and ensured that the tests in this repo still pass.

---

@filippoitaliano @ersel You can install this version by running this command and rebuilding your app. Can you test to check that it fixes the issue for you:

`yarn add '@react-native-community/netinfo@react-native-community/react-native-netinfo#@matt-oakes/issue-32'`

(not a confusing command at all... :wink:)