### PR TITLE
Unify the object shapes and improve type coverage

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -129,7 +129,7 @@ abstract class ConnectivityReceiver {
 
   private void sendConnectivityChangedEvent() {
     getReactContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-      .emit("networkStatusDidChange", createConnectivityEventMap());
+      .emit("netInfo.networkStatusDidChange", createConnectivityEventMap());
   }
 
   private WritableMap createConnectivityEventMap() {

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -134,8 +134,8 @@ abstract class ConnectivityReceiver {
 
   private WritableMap createConnectivityEventMap() {
     WritableMap event = new WritableNativeMap();
-    event.putString("connectionType", mConnectionType);
-    event.putString("effectiveConnectionType", mEffectiveConnectionType);
+    event.putString("type", mConnectionType);
+    event.putString("effectiveType", mEffectiveConnectionType);
     return event;
   }
 }

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -51,8 +51,8 @@ static void RNCReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
 
   if (self->_firstTimeReachability) {
     [self->_firstTimeReachabilityResolvers enumerateObjectsUsingBlock:^(RCTPromiseResolveBlock resolver, BOOL *stop) {
-      resolver(@{@"connectionType": connectionType,
-                 @"effectiveConnectionType": effectiveConnectionType});
+      resolver(@{@"type": connectionType,
+                 @"effectiveType": effectiveConnectionType});
     }];
 
     [self cleanUpFirstTimeReachability];
@@ -60,8 +60,8 @@ static void RNCReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
   }
 
   if (didSetReachabilityFlags && self->_isObserving) {
-    [self sendEventWithName:@"networkStatusDidChange" body:@{@"connectionType": connectionType,
-                                                             @"effectiveConnectionType": effectiveConnectionType}];
+    [self sendEventWithName:@"networkStatusDidChange" body:@{@"type": connectionType,
+                                                             @"effectiveType": effectiveConnectionType}];
   }
 }
 

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -60,7 +60,7 @@ static void RNCReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
   }
 
   if (didSetReachabilityFlags && self->_isObserving) {
-    [self sendEventWithName:@"networkStatusDidChange" body:@{@"type": connectionType,
+    [self sendEventWithName:@"netInfo.networkStatusDidChange" body:@{@"type": connectionType,
                                                              @"effectiveType": effectiveConnectionType}];
   }
 }
@@ -87,7 +87,7 @@ static void RNCReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"networkStatusDidChange"];
+  return @[@"netInfo.networkStatusDidChange"];
 }
 
 - (void)startObserving

--- a/js/__tests__/eventListenerCallbacks.js
+++ b/js/__tests__/eventListenerCallbacks.js
@@ -17,8 +17,8 @@ describe('react-native-netinfo', () => {
       NetInfo.clearEventListeners();
 
       RNCNetInfo.getCurrentConnectivity.mockResolvedValue({
-        connectionType: 'cellular',
-        effectiveConnectionType: '3g',
+        type: 'cellular',
+        effectiveType: '3g',
       });
     });
 
@@ -40,8 +40,8 @@ describe('react-native-netinfo', () => {
       const expectedEffectiveConnectionType = '3g';
 
       NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-        connectionType: expectedConnectionType,
-        effectiveConnectionType: expectedEffectiveConnectionType,
+        type: expectedConnectionType,
+        effectiveType: expectedEffectiveConnectionType,
       });
 
       expect(listener).toBeCalledWith({
@@ -55,12 +55,12 @@ describe('react-native-netinfo', () => {
       NetInfo.addEventListener('connectionChange', listener);
 
       NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-        connectionType: 'cellular',
-        effectiveConnectionType: '3g',
+        type: 'cellular',
+        effectiveType: '3g',
       });
       NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-        connectionType: 'wifi',
-        effectiveConnectionType: 'unknown',
+        type: 'wifi',
+        effectiveType: 'unknown',
       });
 
       // The additional time is from the call on listen
@@ -77,8 +77,8 @@ describe('react-native-netinfo', () => {
       const expectedEffectiveConnectionType = '3g';
 
       NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-        connectionType: expectedConnectionType,
-        effectiveConnectionType: expectedEffectiveConnectionType,
+        type: expectedConnectionType,
+        effectiveType: expectedEffectiveConnectionType,
       });
 
       const expectedResults = {
@@ -99,8 +99,8 @@ describe('react-native-netinfo', () => {
       listener.mockClear();
 
       NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-        connectionType: 'cellular',
-        effectiveConnectionType: '3g',
+        type: 'cellular',
+        effectiveType: '3g',
       });
 
       expect(listener).not.toBeCalled();
@@ -121,8 +121,8 @@ describe('react-native-netinfo', () => {
       const expectedEffectiveConnectionType = '3g';
 
       NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-        connectionType: expectedConnectionType,
-        effectiveConnectionType: expectedEffectiveConnectionType,
+        type: expectedConnectionType,
+        effectiveType: expectedEffectiveConnectionType,
       });
 
       expect(listener1).not.toBeCalled();

--- a/js/__tests__/eventListenerManagement.js
+++ b/js/__tests__/eventListenerManagement.js
@@ -17,8 +17,8 @@ describe('react-native-netinfo', () => {
       NetInfo.clearEventListeners();
 
       NativeModules.RNCNetInfo.getCurrentConnectivity.mockResolvedValue({
-        connectionType: 'cellular',
-        effectiveConnectionType: '3g',
+        type: 'cellular',
+        effectiveType: '3g',
       });
     });
 

--- a/js/__tests__/getConnectionInfo.js
+++ b/js/__tests__/getConnectionInfo.js
@@ -18,8 +18,8 @@ describe('react-native-netinfo', () => {
       const expectedEffectiveConnectionType = '3g';
 
       RNCNetInfo.getCurrentConnectivity.mockResolvedValue({
-        connectionType: expectedConnectionType,
-        effectiveConnectionType: expectedEffectiveConnectionType,
+        type: expectedConnectionType,
+        effectiveType: expectedEffectiveConnectionType,
       });
 
       return expect(NetInfo.getConnectionInfo()).resolves.toEqual({

--- a/js/__tests__/isConnected.js
+++ b/js/__tests__/isConnected.js
@@ -28,8 +28,8 @@ describe('react-native-netinfo', () => {
       NetInfo.clearEventListeners();
 
       RNCNetInfo.getCurrentConnectivity.mockResolvedValue({
-        connectionType: 'cellular',
-        effectiveConnectionType: '3g',
+        type: 'cellular',
+        effectiveType: '3g',
       });
     });
 
@@ -37,8 +37,8 @@ describe('react-native-netinfo', () => {
       CONNECTED_STATES.map(({type, connected}) => {
         it(`should resolve to ${connected.toString()} when the native module returns a ${type} state`, () => {
           NativeModules.RNCNetInfo.getCurrentConnectivity.mockResolvedValue({
-            connectionType: type,
-            effectiveConnectionType: 'unknown',
+            type: type,
+            effectiveType: 'unknown',
           });
 
           return expect(NetInfo.isConnected.fetch()).resolves.toBe(connected);
@@ -120,8 +120,8 @@ describe('react-native-netinfo', () => {
         NetInfo.isConnected.addEventListener('connectionChange', listener);
 
         NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-          connectionType: 'cellular',
-          effectiveConnectionType: '4g',
+          type: 'cellular',
+          effectiveType: '4g',
         });
 
         expect(listener).toBeCalledWith(true);
@@ -132,12 +132,12 @@ describe('react-native-netinfo', () => {
         NetInfo.isConnected.addEventListener('connectionChange', listener);
 
         NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-          connectionType: 'cellular',
-          effectiveConnectionType: '3g',
+          type: 'cellular',
+          effectiveType: '3g',
         });
         NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-          connectionType: 'wifi',
-          effectiveConnectionType: 'unknown',
+          type: 'wifi',
+          effectiveType: 'unknown',
         });
 
         // The additional time is from the call to "getCurrentConnectivity" on listening
@@ -151,8 +151,8 @@ describe('react-native-netinfo', () => {
         NetInfo.isConnected.addEventListener('connectionChange', listener2);
 
         NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-          connectionType: 'cellular',
-          effectiveConnectionType: '2g',
+          type: 'cellular',
+          effectiveType: '2g',
         });
 
         expect(listener1).toBeCalledWith(true);
@@ -168,8 +168,8 @@ describe('react-native-netinfo', () => {
         listener.mockClear();
 
         NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-          connectionType: 'cellular',
-          effectiveConnectionType: '3g',
+          type: 'cellular',
+          effectiveType: '3g',
         });
 
         expect(listener).not.toBeCalled();
@@ -188,8 +188,8 @@ describe('react-native-netinfo', () => {
         listener2.mockClear();
 
         NetInfoEventEmitter.emit(NetInfo.Events.NetworkStatusDidChange, {
-          connectionType: 'unknown',
-          effectiveConnectionType: 'unknown',
+          type: 'unknown',
+          effectiveType: 'unknown',
         });
 
         expect(listener1).not.toBeCalled();

--- a/js/index.js
+++ b/js/index.js
@@ -22,14 +22,14 @@ export type NetInfoData = _NetInfoData;
 export type NetInfoType = _NetInfoType;
 export type NetInfoEffectiveType = _NetInfoEffectiveType;
 
-const DEVICE_CONNECTIVITY_EVENT = 'networkStatusDidChange';
+const DEVICE_CONNECTIVITY_EVENT = 'netInfo.networkStatusDidChange';
 const CHANGE_EVENT_NAME = 'connectionChange';
 
 type ChangeEventName = 'connectionChange';
 
 type ChangeHandler = (data: NetInfoData) => void;
 type IsConnectedHandler = (isConnected: boolean) => void;
-// Ideally we would use the EmitterSubscription from react-native, but it is not publy exported
+// Ideally we would use the EmitterSubscription from react-native, but it is not publicly exported
 type Subscription = {remove: () => void};
 
 const _subscriptions = new Set<ChangeHandler>();

--- a/js/nativeInterface.js
+++ b/js/nativeInterface.js
@@ -9,8 +9,9 @@
  */
 
 import {NativeEventEmitter, NativeModules} from 'react-native';
+import {type NativeInterface} from './types';
 
-const {RNCNetInfo} = NativeModules;
+const RNCNetInfo: NativeInterface = NativeModules.RNCNetInfo;
 
 // Produce an error if we don't have the native module
 if (!RNCNetInfo) {

--- a/js/types.js
+++ b/js/types.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+export type NetInfoType =
+  // iOS & Android
+  | 'none'
+  | 'cellular'
+  | 'unknown'
+  | 'wifi'
+  // Android only
+  | 'bluetooth'
+  | 'ethernet'
+  | 'wimax';
+
+export type NetInfoEffectiveType = 'unknown' | '2g' | '3g' | '4g';
+
+export type NetInfoData = {
+  type: NetInfoType,
+  effectiveType: NetInfoEffectiveType,
+};
+
+export type NativeInterface = {
+  getCurrentConnectivity: () => Promise<NetInfoData>,
+  isConnectionMetered: () => Promise<boolean>,
+  // For the NativeEventEmitter
+  +addListener: (eventType: string) => void,
+  +removeListeners: (count: number) => void,
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "validate:eslint": "eslint 'js/**/*.js' 'example/**/*.js'",
     "validate:flow": "flow check",
     "validate:typescript": "tsc --project ./",
-    "test:jest": "jest js/",
+    "test:jest": "jest '/js/'",
     "test:detox:android:test:debug": "detox test -c android.emu.debug",
     "test:detox:android:test:release": "detox test -c android.emu.release",
     "test:detox:android:build:debug": "detox build -c android.emu.debug",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,12 +29,6 @@ export interface ConnectionInfo {
 
 export interface NetInfoStatic {
   /**
-   * This function is deprecated. Use `getConnectionInfo` instead. Returns a promise that
-   * resolves with one of the deprecated connectivity types listed above.
-   */
-  fetch: () => Promise<ConnectionType>;
-
-  /**
    * Adds an event handler. Supported events:
    *
    * - `connectionChange`: Fires when the network status changes. The argument to the event


### PR DESCRIPTION
# Overview
Based on the comments from @EvanBacon I have:

* Changed the native code to have the same object shape as we send out from Javascript. This eliminates the need for the transformation.
* Improved the flow type coverage. Unfortunately, we need to ignore one error as we can't use the expected type directly from `react-native`. I have added a comment on this case.
* Removed the `fetch()` method from the TypeScript types as this method was removed after being deprecated for years.

# Test Plan
CircleCI should pass still.