### PR TITLE
fix: Issue with getting the network state on Android 7.0+ devices

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -79,12 +79,14 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
     @Override
     public void onAvailable(Network network) {
       mNetwork = network;
+      mNetworkCapabilities = getConnectivityManager().getNetworkCapabilities(network);
       updateAndSend();
     }
 
     @Override
     public void onLosing(Network network, int maxMsToLive) {
       mNetwork = network;
+      mNetworkCapabilities = getConnectivityManager().getNetworkCapabilities(network);
       updateAndSend();
     }
 
@@ -112,6 +114,7 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
     @Override
     public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
       mNetwork = network;
+      mNetworkCapabilities = getConnectivityManager().getNetworkCapabilities(network);
       updateAndSend();
     }
   }


### PR DESCRIPTION
# Overview
Fixes #57.

The issue was caused by a difference in the order that `ConnectivityManager.NetworkCallback` methods are called on that Android version. We now ensure that we always have the correct information to get the network state, regardless of which callback is called when.

# Test Plan
* CircleCI should still pass.
* Users can test this on their devices by installing this branch using this command:

`yarn add @react-native-community/netinfo@react-native-community/react-native-netinfo#matt-oakes/issue-57`
