### PR TITLE
NetworkInfo is null on Huawei devices

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -91,6 +91,10 @@ abstract class ConnectivityReceiver {
   }
 
   String getEffectiveConnectionType(NetworkInfo networkInfo) {
+    if (networkInfo == null) {
+      return EFFECTIVE_CONNECTION_TYPE_UNKNOWN;
+    }
+
     switch (networkInfo.getSubtype()) {
       case TelephonyManager.NETWORK_TYPE_1xRTT:
       case TelephonyManager.NETWORK_TYPE_CDMA:


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
I've seen the following crash, which seems to be limited to Huawei devices:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.net.NetworkInfo.getSubtype()' on a null object reference
       at com.reactnativecommunity.netinfo.ConnectivityReceiver.register(ConnectivityReceiver.java:94)
       at com.reactnativecommunity.netinfo.ConnectivityReceiver.getEffectiveConnectionType(ConnectivityReceiver.java:94)
       at com.reactnativecommunity.netinfo.NetworkCallbackConnectivityReceiver.updateAndSend(NetworkCallbackConnectivityReceiver.java:66)
       at com.reactnativecommunity.netinfo.NetworkCallbackConnectivityReceiver.access$102(NetworkCallbackConnectivityReceiver.java:24)
       at com.reactnativecommunity.netinfo.NetworkCallbackConnectivityReceiver$ConnectivityNetworkCallback.onCapabilitiesChanged(NetworkCallbackConnectivityReceiver.java:111)
       at android.net.ConnectivityManager$CallbackHandler.handleMessage(ConnectivityManager.java:3089)
       at android.os.Handler.dispatchMessage(Handler.java:108)
       at android.os.Looper.loop(Looper.java:166)
       at android.os.HandlerThread.run(HandlerThread.java:65)
```

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
I do not have a Huawei device, but the fix and stack trace are pretty simple.