### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,9 @@ android {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
   }
+  lintOptions{
+    abortOnError false
+  }
 }
 
 repositories {


### PR DESCRIPTION
If having min api version of **21** I cannot build the project when using this library, since upgrading to the latest Android studio, this change fixes that

**Android Studio 3.4.0**
**classpath 'com.android.tools.build:gradle:3.4.0'**

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
