### PR TITLE
Fix export type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -92,4 +92,4 @@ export interface NetInfoStatic {
 }
 
 declare let NetInfo: NetInfoStatic;
-export default NetInfo;
+export = NetInfo;


### PR DESCRIPTION
# Overview
The library uses CommonJS export but the type definition shows that it uses ES export. 