### PR TITLE
Fix: Properly report lost connection as 'none' on Android 24+ (#44)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -70,6 +70,8 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
       } else if (mNetworkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
         connectionType = CONNECTION_TYPE_WIFI;
       }
+    } else {
+      connectionType = CONNECTION_TYPE_NONE;
     }
 
     updateConnectivity(connectionType, effectiveConnectionType);


### PR DESCRIPTION
# Overview
Fixes the issue outlined in #44. With this change it is now possible to receive a "none" connection type and actually know when there is no connection available.

# Test Plan
Tested on device with various combinations of airplane mode, wifi state, cellular radio, and VPN.

Closes #44.