### PR TITLE
chore(ci): Change to the released version of the React Native CircleCI Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rn: react-native-community/react-native@dev:0.1.0-rc12
+  rn: react-native-community/react-native@1.0.0
 
 jobs:
   checkout_code:


### PR DESCRIPTION
# Overview
This changes CircleCI to use the newly published version of the Orb.

# Test Plan
CircleCI tests should pass 🌈 