### PR TITLE
Export the module as an ES Module rather than a CommonJS module

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -172,4 +172,4 @@ const NetInfo = {
   },
 };
 
-module.exports = NetInfo;
+export default NetInfo;


### PR DESCRIPTION
# Overview
Changes from using a CommonJS module to an ES Module. This should fix use with TypeScript without the compatability mode.

# Test Plan
* CircleCI tests should pass.
* Users can test this by installing using `yarn add @react-native-community/netinfo@react-native-community/react-native-netinfo#matt-oakes/export-default`.