### PR TITLE
Correct the Typescript type definitions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,25 +9,7 @@
 
 type ChangeEventName = 'connectionChange';
 
-export type ConnectionType =
-  // iOS & Android
-  | 'none'
-  | 'cellular'
-  | 'unknown'
-  | 'wifi'
-  // Android only
-  | 'bluetooth'
-  | 'ethernet'
-  | 'wimax';
-
-export type EffectiveConnectionType = 'unknown' | '2g' | '3g' | '4g';
-
-export interface ConnectionInfo {
-  type: ConnectionType;
-  effectiveType: EffectiveConnectionType;
-}
-
-export interface NetInfoStatic {
+declare let NetInfo: {
   /**
    * Adds an event handler. Supported events:
    *
@@ -91,5 +73,24 @@ export interface NetInfoStatic {
   isConnectionExpensive: () => Promise<boolean>;
 }
 
-declare let NetInfo: NetInfoStatic;
+namespace NetInfo {
+  export type ConnectionType =
+    // iOS & Android
+    | 'none'
+    | 'cellular'
+    | 'unknown'
+    | 'wifi'
+    // Android only
+    | 'bluetooth'
+    | 'ethernet'
+    | 'wimax';
+
+  export type EffectiveConnectionType = 'unknown' | '2g' | '3g' | '4g';
+
+  export interface ConnectionInfo {
+    type: ConnectionType;
+    effectiveType: EffectiveConnectionType;
+  }
+}
+
 export = NetInfo;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -92,4 +92,4 @@ export interface NetInfoStatic {
 }
 
 declare let NetInfo: NetInfoStatic;
-export default NetInfo;
+export = NetInfo;


### PR DESCRIPTION
# Overview
Corrects the Typescript type definitions for users who do not have `esModuleInterop` turned on.

Supersedes #69.

# Test Plan
Tested on a Typescript project with the option on and off.
