### PR TITLE
fix: Remove uses of deprecated types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -88,8 +88,8 @@ declare namespace NetInfo {
   export type NetInfoEffectiveType = 'unknown' | '2g' | '3g' | '4g';
 
   export interface NetInfoData {
-    type: ConnectionType;
-    effectiveType: EffectiveConnectionType;
+    type: NetInfoType;
+    effectiveType: NetInfoEffectiveType;
   }
 }
 


### PR DESCRIPTION
Hi,

I noticed that #82 missed a couple uses of deprecated types which were causing issues if you're using the NetInfoData interface.