### PR TITLE
Add defensive catch when unregistering network

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -47,6 +47,8 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
       getConnectivityManager().unregisterNetworkCallback(mNetworkCallback);
     } catch (SecurityException e) {
       setNoNetworkPermission();
+    } catch (IllegalArgumentException e) {
+      // ignore this, it is expected when the callback was not registered successfully
     }
   }
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
We've seen a couple crashes on various Android API 24+ devices when this unregister network call is made. I don't have repro steps but have included an example stack trace showing where it originates during Activity.onPause calls.

Caused by java.lang.IllegalArgumentException: Invalid NetworkCallback
       at android.net.ConnectivityManager.unregisterNetworkCallback(ConnectivityManager.java:3593)
       at com.reactnativecommunity.netinfo.NetworkCallbackConnectivityReceiver.unregister(NetworkCallbackConnectivityReceiver.java:47)
       at com.reactnativecommunity.netinfo.NetInfoModule.onHostPause(NetInfoModule.java:43)
       at com.facebook.react.bridge.ReactContext.onHostPause(ReactContext.java:221)
       at com.facebook.react.ReactInstanceManager.moveToBeforeResumeLifecycleState(ReactInstanceManager.java:673)
       at com.facebook.react.ReactInstanceManager.onHostPause(ReactInstanceManager.java:497)
       at com.facebook.react.ReactInstanceManager.onHostPause(ReactInstanceManager.java:516)
       at com.facebook.react.ReactActivityDelegate.onPause(ReactActivityDelegate.java:94)
       at com.facebook.react.ReactActivity.onPause(ReactActivity.java:58)


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

