### PR TITLE
docs: Add instructions for integrating with Jest unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,13 @@ const YourComplement = () => {
 };
 ```
 
-## Known issues with the iOS simulator
+## Troubleshooting
+
+### Errors while running Jest tests
+
+Follow the [guide to integrate with Jest](/docs/Jest-Integration.md).
+
+### Issues with the iOS simulator
 
 There is a [known](http://openradar.appspot.com/14585459) [issue](http://www.openradar.appspot.com/29913522) with the iOS Simulator which causes it to not receive network change notifications correctly when the host machine disconnects and then connects to Wifi. If you are having issues with iOS then please test on an actual device before reporting any bugs.
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,24 @@ const YourComplement = () => {
 
 ### Errors while running Jest tests
 
-Follow the [guide to integrate with Jest](/docs/Jest-Integration.md).
+If you do not have a Jest Setup file configured, you should add the following to your Jest settings and create the `jest.setup.js` file in project root:
+
+```js
+setupFiles: ['<rootDir>/jest.setup.js']
+```
+
+You should then add the following to your Jest setup file to mock the NetInfo Native Module:
+
+```js
+import { NativeModules } from 'react-native';
+
+NativeModules.RNCNetInfo = {
+  getCurrentConnectivity: jest.fn(),
+  isConnectionMetered: jest.fn(),
+  addListener: jest.fn(),
+  removeListeners: jest.fn()
+};
+```
 
 ### Issues with the iOS simulator
 

--- a/src/internal/nativeInterface.ts
+++ b/src/internal/nativeInterface.ts
@@ -19,6 +19,8 @@ if (!RNCNetInfo) {
 • Run \`react-native link @react-native-community/netinfo\` in the project root.
 • Rebuild and re-run the app.
 • If you are using CocoaPods on iOS, run \`pod install\` in the \`ios\` directory and then rebuild and re-run the app. You may also need to re-open Xcode to get the new pods.
+• Check that the library was linked correctly when you used the link command by running through the manual installation instructions in the README.
+* If you are getting this error while unit testing you need to mock the native module. Follow the guide in the README.
 
 If none of these fix the issue, please open an issue on the Github repository: https://github.com/react-native-community/react-native-netinfo`);
 }


### PR DESCRIPTION
# Overview
Adds instructions for getting the module to work correctly with Jest.

Currently the suggested mock is just enough to get the library running. In the future we can add a better mock which can be used to actually control and mock network conditions.

# Test Plan
Fixes #75
