### PR TITLE
feat(Android): Detect and report VPN connections correctly on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The `details` value depends on the `type` value.
 
 `details` is `null`.
 
-##### `type` is `wifi`, `bluetooth`, `ethernet`, or `wimax`
+##### `type` is `wifi`, `bluetooth`, `ethernet`, `wimax`, `vpn`, or `other`
 
 `details` has these properties:
 
@@ -170,15 +170,17 @@ The `details` value depends on the `type` value.
 #### `NetInfoStateType`
 Describes the current type of network connection. It is an enum with these possible values:
 
-| Value       | Platform     | Description                                         |
-| ----------- | ------------ | --------------------------------------------------- |
-| `none`      | Android, iOS | No network connection is active                     |
-| `unknown`   | Android, iOS | The network state could not be determined           |
-| `cellular`  | Android, iOS | The active network is a cellular connection         |
-| `wifi`      | Android, iOS | The active network is a Wifi connection             |
-| `bluetooth` | Android      | The active network over Bluetooth                   |
-| `ethernet`  | Android      | The active network over a wired ethernet connection |
-| `wimax`     | Android      | The active network over a WiMax connection          |
+| Value       | Platform     | Description                                                |
+| ----------- | ------------ | ---------------------------------------------------------- |
+| `none`      | Android, iOS | No network connection is active                            |
+| `unknown`   | Android, iOS | The network state could not or has yet to be be determined |
+| `cellular`  | Android, iOS | The active network is a cellular connection                |
+| `wifi`      | Android, iOS | The active network is a Wifi connection                    |
+| `bluetooth` | Android      | The active network over Bluetooth                          |
+| `ethernet`  | Android      | The active network over a wired ethernet connection        |
+| `wimax`     | Android      | The active network over a WiMax connection                 |
+| `vpn`       | Android      | The active network over a VPN connection                   |
+| `other`     | Android, iOS | The active network over another type of network            |
 
 #### `NetInfoCellularGeneration`
 Describes the current generation of the `cellular` connection. It is an enum with these possible values:

--- a/README.md
+++ b/README.md
@@ -174,23 +174,23 @@ Describes the current type of network connection. It is an enum with these possi
 | ----------- | ------------ | ---------------------------------------------------------- |
 | `none`      | Android, iOS | No network connection is active                            |
 | `unknown`   | Android, iOS | The network state could not or has yet to be be determined |
-| `cellular`  | Android, iOS | The active network is a cellular connection                |
-| `wifi`      | Android, iOS | The active network is a Wifi connection                    |
-| `bluetooth` | Android      | The active network over Bluetooth                          |
-| `ethernet`  | Android      | The active network over a wired ethernet connection        |
-| `wimax`     | Android      | The active network over a WiMax connection                 |
-| `vpn`       | Android      | The active network over a VPN connection                   |
-| `other`     | Android, iOS | The active network over another type of network            |
+| `cellular`  | Android, iOS | Active network over cellular                               |
+| `wifi`      | Android, iOS | Active network over Wifi                                   |
+| `bluetooth` | Android      | Active network over Bluetooth                              |
+| `ethernet`  | Android      | Active network over wired ethernet                         |
+| `wimax`     | Android      | Active network over WiMax                                  |
+| `vpn`       | Android      | Active network over VPN                                    |
+| `other`     | Android, iOS | Active network over another type of network                |
 
 #### `NetInfoCellularGeneration`
 Describes the current generation of the `cellular` connection. It is an enum with these possible values:
 
-| Value     | Description                                                                                                              |
-| --------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `null`    | Either we are not currently connected to a cellular network or type could not be determined                              |
-| `2g`      | We are currently connected to a 2G cellular network. Includes CDMA, EDGE, GPRS, and IDEN type connections                |
-| `3g`      | We are currently connected to a 3G cellular network. Includes EHRPD, EVDO, HSPA, HSUPA, HSDPA, and UTMS type connections |
-| `4g`      | We are currently connected to a 4G cellular network. Includes HSPAP and LTE type connections                             |
+| Value     | Description                                                                                                       |
+| --------- | ----------------------------------------------------------------------------------------------------------------- |
+| `null`    | Either we are not currently connected to a cellular network or type could not be determined                       |
+| `2g`      | Currently connected to a 2G cellular network. Includes CDMA, EDGE, GPRS, and IDEN type connections                |
+| `3g`      | Currently connected to a 3G cellular network. Includes EHRPD, EVDO, HSPA, HSUPA, HSDPA, and UTMS type connections |
+| `4g`      | Currently connected to a 4G cellular network. Includes HSPAP and LTE type connections                             |
 
 ### Methods
 

--- a/android/src/main/java/com/reactnativecommunity/netinfo/BroadcastReceiverConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/BroadcastReceiverConnectivityReceiver.java
@@ -53,7 +53,7 @@ public class BroadcastReceiverConnectivityReceiver extends ConnectivityReceiver 
 
   @SuppressLint("MissingPermission")
   private void updateAndSendConnectionType() {
-    String connectionType = CONNECTION_TYPE_UNKNOWN;
+    String connectionType = CONNECTION_TYPE_OTHER;
     String cellularGeneration = null;
 
     try {
@@ -80,6 +80,8 @@ public class BroadcastReceiverConnectivityReceiver extends ConnectivityReceiver 
           case ConnectivityManager.TYPE_WIMAX:
             connectionType = CONNECTION_TYPE_WIMAX;
             break;
+          case ConnectivityManager.TYPE_VPN:
+            connectionType = CONNECTION_TYPE_VPN;
         }
       }
     } catch (SecurityException e) {

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -29,6 +29,8 @@ abstract class ConnectivityReceiver {
   static final String CONNECTION_TYPE_UNKNOWN = "unknown";
   static final String CONNECTION_TYPE_WIFI = "wifi";
   static final String CONNECTION_TYPE_WIMAX = "wimax";
+  static final String CONNECTION_TYPE_VPN = "vpn";
+  static final String CONNECTION_TYPE_OTHER = "other";
 
   // Based on the EffectiveConnectionType enum described in the W3C Network Information API spec
   // (https://wicg.github.io/netinfo/).

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -57,7 +57,7 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
 
   @SuppressLint("MissingPermission")
   private void updateAndSend() {
-    String connectionType = CONNECTION_TYPE_UNKNOWN;
+    String connectionType = CONNECTION_TYPE_OTHER;
     String cellularGeneration = null;
 
     if (mNetworkCapabilities != null) {
@@ -74,6 +74,8 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
         connectionType = CONNECTION_TYPE_ETHERNET;
       } else if (mNetworkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
         connectionType = CONNECTION_TYPE_WIFI;
+      } else if (mNetworkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+        connectionType = CONNECTION_TYPE_VPN;
       }
     } else {
       connectionType = CONNECTION_TYPE_NONE;

--- a/src/internal/__tests__/deprecatedUtils.ts
+++ b/src/internal/__tests__/deprecatedUtils.ts
@@ -156,6 +156,38 @@ describe('Deprecated utils', () => {
         effectiveType: 'unknown',
       },
     },
+    {
+      title: 'VPN',
+      input: {
+        type: NetInfoStateType.vpn,
+        isConnected: true,
+        details: {
+          isConnectionExpensive: false,
+        },
+      },
+      isConnected: true,
+      isExpensive: false,
+      depreacted: {
+        type: 'unknown',
+        effectiveType: 'unknown',
+      },
+    },
+    {
+      title: 'Other',
+      input: {
+        type: NetInfoStateType.other,
+        isConnected: true,
+        details: {
+          isConnectionExpensive: false,
+        },
+      },
+      isConnected: true,
+      isExpensive: false,
+      depreacted: {
+        type: 'unknown',
+        effectiveType: 'unknown',
+      },
+    },
   ];
 
   describe('convertState', () => {

--- a/src/internal/deprecatedUtils.ts
+++ b/src/internal/deprecatedUtils.ts
@@ -24,8 +24,15 @@ export function convertState(
     effectiveType = input.details.cellularGeneration || 'unknown';
   }
 
+  // Ensure we don't sent types that the old meethods did not support. Set them to "unknown"
+  const type: DeprecatedTypes.NetInfoType =
+    input.type === Types.NetInfoStateType.vpn ||
+    input.type === Types.NetInfoStateType.other
+      ? 'unknown'
+      : input.type;
+
   return {
-    type: input.type,
+    type,
     effectiveType,
   };
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -15,6 +15,8 @@ export enum NetInfoStateType {
   bluetooth = 'bluetooth',
   ethernet = 'ethernet',
   wimax = 'wimax',
+  vpn = 'vpn',
+  other = 'other',
 }
 
 export enum NetInfoCellularGeneration {
@@ -62,6 +64,8 @@ export type NetInfoEthernetState = NetInfoConnectedState<
   NetInfoStateType.ethernet
 >;
 export type NetInfoWimaxState = NetInfoConnectedState<NetInfoStateType.wimax>;
+export type NetInfoVpnState = NetInfoConnectedState<NetInfoStateType.vpn>;
+export type NetInfoOtherState = NetInfoConnectedState<NetInfoStateType.other>;
 
 export type NetInfoState =
   | NetInfoUnknownState
@@ -70,7 +74,9 @@ export type NetInfoState =
   | NetInfoWifiState
   | NetInfoBluetoothState
   | NetInfoEthernetState
-  | NetInfoWimaxState;
+  | NetInfoWimaxState
+  | NetInfoVpnState
+  | NetInfoOtherState;
 
 export type NetInfoChangeHandler = (state: NetInfoState) => void;
 export type NetInfoSubscription = () => void;


### PR DESCRIPTION
# Overview
Adds the ability to detch VPN connections on Android. These were previously reported as "unknown". I have also added a fallback to "other" if we have a connection, but can't determine the type. This means we can handle new types being added without the user being reported incorrectly as "offline".

Fixes #87.

# Test Plan
Tested on multiple Android devices with a VPN client.