### PR TITLE
fix(Android): Send a "none" status if the device has no active network on launch

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -39,6 +39,12 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
   void register() {
     try {
       getConnectivityManager().registerDefaultNetworkCallback(mNetworkCallback);
+
+      // If we currently have no active network, we are not going to get a callback below, so we
+      // should manually send a "none" event
+      if (getConnectivityManager().getActiveNetwork() == null) {
+        updateAndSend();
+      }
     } catch (SecurityException e) {
       setNoNetworkPermission();
     }


### PR DESCRIPTION
# Overview
If a subscription to the network state was made on Android N+ when there was no active network, none of the callbacks would get called. Therefore, the state would be incorrectly reported as "unknown".

This PR adds a check if no active network on register and then manually calls `updateAndSend()` to emit the `none` state.

Fixes #77

# Test Plan
Tested on a Pixel 2 in various states.