### PR TITLE
feat(windows): Add Windows as a supported platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # `@react-native-community/netinfo`
 
-[![CircleCI Status](https://img.shields.io/circleci/project/github/react-native-community/react-native-netinfo/master.svg)](https://circleci.com/gh/react-native-community/workflows/react-native-netinfo/tree/master) ![Supports Android and iOS](https://img.shields.io/badge/platforms-android%20|%20ios%20|%20windows-lightgrey.svg) ![MIT License](https://img.shields.io/npm/l/@react-native-community/netinfo.svg)
+[![CircleCI Status](https://img.shields.io/circleci/project/github/react-native-community/react-native-netinfo/master.svg)](https://circleci.com/gh/react-native-community/workflows/react-native-netinfo/tree/master) ![Supports Android, iOS, and Windows](https://img.shields.io/badge/platforms-android%20|%20ios%20|%20windows-lightgrey.svg) ![MIT License](https://img.shields.io/npm/l/@react-native-community/netinfo.svg)
 
 React Native Network Info API for Android, iOS & Windows. It allows you to get information on:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 # `@react-native-community/netinfo`
 
-[![CircleCI Status](https://img.shields.io/circleci/project/github/react-native-community/react-native-netinfo/master.svg)](https://circleci.com/gh/react-native-community/workflows/react-native-netinfo/tree/master) ![Supports Android and iOS](https://img.shields.io/badge/platforms-android%20|%20ios-lightgrey.svg) ![MIT License](https://img.shields.io/npm/l/@react-native-community/netinfo.svg)
+[![CircleCI Status](https://img.shields.io/circleci/project/github/react-native-community/react-native-netinfo/master.svg)](https://circleci.com/gh/react-native-community/workflows/react-native-netinfo/tree/master) ![Supports Android and iOS](https://img.shields.io/badge/platforms-android%20|%20ios%20|%20windows-lightgrey.svg) ![MIT License](https://img.shields.io/npm/l/@react-native-community/netinfo.svg)
 
-React Native Network Info API for Android & iOS. It allows you to get information on:
+React Native Network Info API for Android, iOS & Windows. It allows you to get information on:
 
 * Connection type
 * Connection quality
@@ -77,6 +77,28 @@ protected List<ReactPackage> getPackages() {
     );
 }
 ```
+</details>
+
+<details>
+<summary>Manually link the library on Windows</summary>
+
+* Open the solution in Visual Studio for your Windows apps
+* Right click in the Explorer and click Add > Existing Project...
+* Navigate to `./<app-name>/node_modules/@react-native-community/netinfo/windows/RNCNetInfo/` and add `RNCNetInfo.csproj`
+* This time right click on your React Native Windows app under your solutions directory and click Add > Reference...
+* Check the `RNCNetInfo` you just added and press ok
+* Open up `MainReactNativeHost.cs` for your app and edit the file like so:
+
+```diff
++ using ReactNativeCommunity.NetInfo;
+......
+        protected override List<IReactPackage> Packages => new List<IReactPackage>
+        {
+            new MainReactPackage(),
++           new RNCNetInfoPackage(),
+        };
+```
+
 </details>
 
 ## Migrating from the core `react-native` module
@@ -170,17 +192,17 @@ The `details` value depends on the `type` value.
 #### `NetInfoStateType`
 Describes the current type of network connection. It is an enum with these possible values:
 
-| Value       | Platform     | Description                                                |
-| ----------- | ------------ | ---------------------------------------------------------- |
-| `none`      | Android, iOS | No network connection is active                            |
-| `unknown`   | Android, iOS | The network state could not or has yet to be be determined |
-| `cellular`  | Android, iOS | Active network over cellular                               |
-| `wifi`      | Android, iOS | Active network over Wifi                                   |
-| `bluetooth` | Android      | Active network over Bluetooth                              |
-| `ethernet`  | Android      | Active network over wired ethernet                         |
-| `wimax`     | Android      | Active network over WiMax                                  |
-| `vpn`       | Android      | Active network over VPN                                    |
-| `other`     | Android, iOS | Active network over another type of network                |
+| Value       | Platform              | Description                                                |
+| ----------- | --------------------- | ---------------------------------------------------------- |
+| `none`      | Android, iOS, Windows | No network connection is active                            |
+| `unknown`   | Android, iOS, Windows | The network state could not or has yet to be be determined |
+| `cellular`  | Android, iOS, Windows | Active network over cellular                               |
+| `wifi`      | Android, iOS, Windows | Active network over Wifi                                   |
+| `bluetooth` | Android               | Active network over Bluetooth                              |
+| `ethernet`  | Android, Windows      | Active network over wired ethernet                         |
+| `wimax`     | Android               | Active network over WiMax                                  |
+| `vpn`       | Android               | Active network over VPN                                    |
+| `other`     | Android, iOS, Windows | Active network over another type of network                |
 
 #### `NetInfoCellularGeneration`
 Describes the current generation of the `cellular` connection. It is an enum with these possible values:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "/android",
     "!/android/build",
     "/ios",
+    "/windows",
     "/src",
     "/lib",
     "/*.podspec"

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,0 +1,78 @@
+*AppPackages*
+*BundleArtifacts*
+*ReactAssets*
+
+# OS junk files
+[Tt]humbs.db
+*.DS_Store
+
+# Visual Studio files
+*.[Oo]bj
+*.user
+*.aps
+*.pch
+*.vspscc
+*.vssscc
+*_i.c
+*_p.c
+*.ncb
+*.suo
+*.tlb
+*.tlh
+*.bak
+*.[Cc]ache
+*.ilk
+*.log
+*.lib
+*.sbr
+*.sdf
+*.opensdf
+*.opendb
+*.unsuccessfulbuild
+ipch/
+[Oo]bj/
+[Bb]in
+[Dd]ebug*/
+[Rr]elease*/
+Ankh.NoLoad
+
+# MonoDevelop
+*.pidb
+*.userprefs
+
+# Tooling
+_ReSharper*/
+*.resharper
+[Tt]est[Rr]esult*
+*.sass-cache
+
+# Project files
+[Bb]uild/
+
+# Subversion files
+.svn
+
+# Office Temp Files
+~$*
+
+# vim Temp Files
+*~
+
+# NuGet
+packages/
+*.nupkg
+
+# ncrunch
+*ncrunch*
+*crunch*.local.xml
+
+# Visual Studio database projects
+*.dbmdl
+
+# Test files
+*.testsettings
+
+#Other files
+*.DotSettings
+.vs/
+*project.lock.json

--- a/windows/RNCNetInfo.sln
+++ b/windows/RNCNetInfo.sln
@@ -1,0 +1,86 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RNCNetInfo", "RNCNetInfo\RNCNetInfo.csproj", "{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactNative", "..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj", "{C7673AD5-E3AA-468C-A5FD-FA38154E205C}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChakraBridge", "..\node_modules\react-native-windows\ReactWindows\ChakraBridge\ChakraBridge.vcxproj", "{4B72C796-16D5-4E3A-81C0-3E36F531E578}"
+EndProject
+Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\node_modules\react-native-windows\ReactWindows\ReactNative.Shared\ReactNative.Shared.projitems*{c7673ad5-e3aa-468c-a5fd-fa38154e205c}*SharedItemsImports = 4
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Development|ARM = Development|ARM
+		Development|x64 = Development|x64
+		Development|x86 = Development|x86
+		Release|ARM = Release|ARM
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|ARM.ActiveCfg = Debug|ARM
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|ARM.Build.0 = Debug|ARM
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|x64.ActiveCfg = Debug|x64
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|x64.Build.0 = Debug|x64
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|x86.ActiveCfg = Debug|x86
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|x86.Build.0 = Debug|x86
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|ARM.ActiveCfg = Development|ARM
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|ARM.Build.0 = Development|ARM
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|x64.ActiveCfg = Development|x64
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|x64.Build.0 = Development|x64
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|x86.ActiveCfg = Development|x86
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|x86.Build.0 = Development|x86
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|ARM.ActiveCfg = Release|ARM
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|ARM.Build.0 = Release|ARM
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|x64.ActiveCfg = Release|x64
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|x64.Build.0 = Release|x64
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|x86.ActiveCfg = Release|x86
+		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|x86.Build.0 = Release|x86
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|ARM.ActiveCfg = Debug|ARM
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|ARM.Build.0 = Debug|ARM
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|x64.ActiveCfg = Debug|x64
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|x64.Build.0 = Debug|x64
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|x86.ActiveCfg = Debug|x86
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|x86.Build.0 = Debug|x86
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Development|ARM.ActiveCfg = Debug|ARM
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Development|ARM.Build.0 = Debug|ARM
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Development|x64.ActiveCfg = Debug|x64
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Development|x64.Build.0 = Debug|x64
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Development|x86.ActiveCfg = Debug|x86
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Development|x86.Build.0 = Debug|x86
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Release|ARM.ActiveCfg = Release|ARM
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Release|ARM.Build.0 = Release|ARM
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Release|x64.ActiveCfg = Release|x64
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Release|x64.Build.0 = Release|x64
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Release|x86.ActiveCfg = Release|x86
+		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Release|x86.Build.0 = Release|x86
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Debug|ARM.ActiveCfg = Debug|ARM
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Debug|ARM.Build.0 = Debug|ARM
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Debug|x64.ActiveCfg = Debug|x64
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Debug|x64.Build.0 = Debug|x64
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Debug|x86.ActiveCfg = Debug|Win32
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Debug|x86.Build.0 = Debug|Win32
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Development|ARM.ActiveCfg = Debug|ARM
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Development|ARM.Build.0 = Debug|ARM
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Development|x64.ActiveCfg = Debug|x64
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Development|x64.Build.0 = Debug|x64
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Development|x86.ActiveCfg = Debug|Win32
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Development|x86.Build.0 = Debug|Win32
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|ARM.ActiveCfg = Release|ARM
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|ARM.Build.0 = Release|ARM
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x64.ActiveCfg = Release|x64
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x64.Build.0 = Release|x64
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x86.ActiveCfg = Release|Win32
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/windows/RNCNetInfo/DefaultNetworkInformation.cs
+++ b/windows/RNCNetInfo/DefaultNetworkInformation.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Windows.Networking.Connectivity;
+
+namespace ReactNativeCommunity.NetInfo
+{
+    class DefaultNetworkInformation : INetworkInformation
+    {
+        public event NetworkStatusChangedEventHandler NetworkStatusChanged;
+
+        public void Start()
+        {
+            NetworkInformation.NetworkStatusChanged += OnNetworkStatusChanged;
+        }
+
+        public void Stop()
+        {
+            NetworkInformation.NetworkStatusChanged -= OnNetworkStatusChanged;
+        }
+
+        public IConnectionProfile GetInternetConnectionProfile()
+        {
+            var profile = NetworkInformation.GetInternetConnectionProfile();
+            return profile != null
+                ? new ConnectionProfileImpl(profile)
+                : null;
+        }
+
+        private void OnNetworkStatusChanged(object sender)
+        {
+            NetworkStatusChanged?.Invoke(sender);
+        }
+
+        class ConnectionProfileImpl : IConnectionProfile
+        {
+            private readonly ConnectionProfile _profile;
+
+            public ConnectionProfileImpl(ConnectionProfile profile)
+            {
+                _profile = profile;
+            }
+
+            public NetworkConnectivityLevel ConnectivityLevel
+            {
+                get
+                {
+                    return _profile.GetNetworkConnectivityLevel();
+                }
+            }
+
+            public NetworkConnectionType ConnectionType
+            {
+                get
+                {
+                    if (_profile.IsWlanConnectionProfile)
+                    {
+                        return NetworkConnectionType.Wifi;
+                    }
+                    else if (_profile.IsWwanConnectionProfile)
+                    {
+                        return NetworkConnectionType.Cellular;
+                    }
+                    else
+                    {
+                        // If we have a connection that is not a Wifi connection or a Cellular
+                        // connection, then let's fallback and assume it's an Ethernet connection
+                        return NetworkConnectionType.Ethernet;
+                    }
+                }
+            }
+
+            public CellularGeneration CellularGeneration
+            {
+                get
+                {
+                    if (!_profile.IsWwanConnectionProfile)
+                    {
+                        return CellularGeneration.None;
+                    }
+
+                    var dataClass = _profile.WwanConnectionProfileDetails.GetCurrentDataClass();
+
+                    switch (dataClass) {
+                        case WwanDataClass.None:
+                            return CellularGeneration.None;
+                        case WwanDataClass.Edge:
+                        case WwanDataClass.Gprs:
+                            return CellularGeneration.Generation2;
+                        case WwanDataClass.Cdma1xEvdo:
+                        case WwanDataClass.Cdma1xEvdoRevA:
+                        case WwanDataClass.Cdma1xEvdoRevB:
+                        case WwanDataClass.Cdma1xEvdv:
+                        case WwanDataClass.Cdma1xRtt:
+                        case WwanDataClass.Cdma3xRtt:
+                        case WwanDataClass.Hsdpa:
+                        case WwanDataClass.Hsupa:
+                        case WwanDataClass.Umts:
+                            return CellularGeneration.Generation3;
+                        case WwanDataClass.CdmaUmb:
+                        case WwanDataClass.LteAdvanced:
+                            return CellularGeneration.Generation4;
+                        case WwanDataClass.Custom:
+                        default:
+                            return CellularGeneration.Unknown;
+                    }
+                }
+            }
+
+            public NetworkCostType ConnectionCost
+            {
+                get
+                {
+                    return _profile.GetConnectionCost().NetworkCostType;
+                }
+            }
+        }
+    }
+}

--- a/windows/RNCNetInfo/DefaultNetworkInformation.cs
+++ b/windows/RNCNetInfo/DefaultNetworkInformation.cs
@@ -61,11 +61,21 @@ namespace ReactNativeCommunity.NetInfo
                     {
                         return NetworkConnectionType.Cellular;
                     }
+
+                    var networkAdapter = _profile.NetworkAdapter;
+                    if (networkAdapter == null)
+                    {
+                        return NetworkConnectionType.Unknown;
+                    }
+
+                    // Possible values: https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib
+                    if (networkAdapter.IanaInterfaceType == 6u)
+                    {
+                        return NetworkConnectionType.Ethernet;
+                    }
                     else
                     {
-                        // If we have a connection that is not a Wifi connection or a Cellular
-                        // connection, then let's fallback and assume it's an Ethernet connection
-                        return NetworkConnectionType.Ethernet;
+                        return NetworkConnectionType.Other;
                     }
                 }
             }

--- a/windows/RNCNetInfo/IConnectionProfile.cs
+++ b/windows/RNCNetInfo/IConnectionProfile.cs
@@ -11,7 +11,8 @@ namespace ReactNativeCommunity.NetInfo
         None,
         Cellular,
         Ethernet,
-        Wifi
+        Wifi,
+        Other
     }
 
     public enum CellularGeneration

--- a/windows/RNCNetInfo/IConnectionProfile.cs
+++ b/windows/RNCNetInfo/IConnectionProfile.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Windows.Networking.Connectivity;
+
+namespace ReactNativeCommunity.NetInfo
+{
+    public enum NetworkConnectionType
+    {
+        Unknown,
+        None,
+        Cellular,
+        Ethernet,
+        Wifi
+    }
+
+    public enum CellularGeneration
+    {
+        Unknown,
+        None,
+        Generation2,
+        Generation3,
+        Generation4
+    }
+
+    /// <summary>
+    /// An interface for network connection profiles.
+    /// </summary>
+    public interface IConnectionProfile
+    {
+        /// <summary>
+        /// A value that indicates the network connectivity level.
+        /// </summary>
+        NetworkConnectivityLevel ConnectivityLevel { get; }
+
+        /// <summary>
+        /// A value that indicates the network connection type.
+        /// </summary>
+        NetworkConnectionType ConnectionType { get; }
+
+        /// <summary>
+        /// A value that indicates the cellular generation currently in use, if ConnectionType is Cellular.
+        /// </summary>
+        CellularGeneration CellularGeneration { get; }
+
+        /// <summary>
+        /// A value that indicates the network connection cost, i.e. is the connection metered.
+        /// </summary>
+        NetworkCostType ConnectionCost { get; }
+    }
+}

--- a/windows/RNCNetInfo/INetworkInformation.cs
+++ b/windows/RNCNetInfo/INetworkInformation.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Windows.Networking.Connectivity;
+
+namespace ReactNativeCommunity.NetInfo
+{
+    /// <summary>
+    /// An interface for network information status and updates.
+    /// </summary>
+    public interface INetworkInformation
+    {
+        /// <summary>
+        /// An event that occurs whenever the network status changes.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1009:DeclareEventHandlersCorrectly", Justification = "API matches Windows.Networking.Connectivity.NetworkingInformation.")]
+        event NetworkStatusChangedEventHandler NetworkStatusChanged;
+
+        /// <summary>
+        /// Gets the connection profile associated with the internet connection
+        /// currently used by the local machine.
+        /// </summary>
+        /// <returns>
+        /// The profile for the connection currently used to connect the machine
+        /// to the Internet, or null if there is no connection profile with a 
+        /// suitable connection.
+        /// </returns>
+        IConnectionProfile GetInternetConnectionProfile();
+
+        /// <summary>
+        /// Starts observing network status changes.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops observing network status changes.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/windows/RNCNetInfo/Properties/AssemblyInfo.cs
+++ b/windows/RNCNetInfo/Properties/AssemblyInfo.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RNCNetInfo")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RNCNetInfo")]
+[assembly: AssemblyCopyright("Copyright © 2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]

--- a/windows/RNCNetInfo/Properties/RNCNetInfo.rd.xml
+++ b/windows/RNCNetInfo/Properties/RNCNetInfo.rd.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This file contains Runtime Directives, specifications about types your application accesses
+    through reflection and other dynamic code patterns. Runtime Directives are used to control the
+    .NET Native optimizer and ensure that it does not remove code accessed by your library. If your
+    library does not do any reflection, then you generally do not need to edit this file. However,
+    if your library reflects over types, especially types passed to it or derived from its types,
+    then you should write Runtime Directives.
+
+    The most common use of reflection in libraries is to discover information about types passed
+    to the library. Runtime Directives have three ways to express requirements on types passed to
+    your library.
+
+    1.  Parameter, GenericParameter, TypeParameter, TypeEnumerableParameter
+        Use these directives to reflect over types passed as a parameter.
+
+    2.  SubTypes
+        Use a SubTypes directive to reflect over types derived from another type.
+
+    3.  AttributeImplies
+        Use an AttributeImplies directive to indicate that your library needs to reflect over
+        types or methods decorated with an attribute.
+
+    For more information on writing Runtime Directives for libraries, please visit
+    http://go.microsoft.com/fwlink/?LinkID=391919
+-->
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="RNCNetInfo">
+
+  	<!-- add directives for your library here -->
+
+  </Library>
+</Directives>

--- a/windows/RNCNetInfo/RNCNetInfo.csproj
+++ b/windows/RNCNetInfo/RNCNetInfo.csproj
@@ -1,0 +1,157 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RNCNetInfo</RootNamespace>
+    <AssemblyName>RNCNetInfo</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReactWindowsRoot>..\..\node_modules</ReactWindowsRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' != 'Development'">
+    <ReactWindowsRoot>..\..\..\..</ReactWindowsRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="DefaultNetworkInformation.cs" />
+    <Compile Include="IConnectionProfile.cs" />
+    <Compile Include="INetworkInformation.cs" />
+    <Compile Include="RNCNetInfoModule.cs" />
+    <Compile Include="RNCNetInfoPackage.cs" />
+    <EmbeddedResource Include="Properties\RNCNetInfo.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>6.0.6</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(ReactWindowsRoot)\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
+      <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
+      <Name>ReactNative</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Development|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Development\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Development|ARM'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Development\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Development|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Development\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/windows/RNCNetInfo/RNCNetInfoModule.cs
+++ b/windows/RNCNetInfo/RNCNetInfoModule.cs
@@ -22,6 +22,7 @@ namespace ReactNativeCommunity.NetInfo
         private const string CONNECTION_TYPE_NONE = "none";
         private const string CONNECTION_TYPE_UNKNOWN = "unknown";
         private const string CONNECTION_TYPE_WIFI = "wifi";
+        private const string CONNECTION_TYPE_OTHER = "other";
 
         private const string CELLULAR_GENERATION_2G = "2g";
         private const string CELLULAR_GENERATION_3G = "3g";
@@ -157,6 +158,8 @@ namespace ReactNativeCommunity.NetInfo
                     return CONNECTION_TYPE_ETHERNET;
                 case NetworkConnectionType.Wifi:
                     return CONNECTION_TYPE_WIFI;
+                case NetworkConnectionType.Other:
+                    return CONNECTION_TYPE_OTHER;
                 default:
                     return CONNECTION_TYPE_UNKNOWN;
             }

--- a/windows/RNCNetInfo/RNCNetInfoModule.cs
+++ b/windows/RNCNetInfo/RNCNetInfoModule.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Portions derived from React Native:
+// Copyright (c) 2015-present, Facebook, Inc.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json.Linq;
+using ReactNative.Bridge;
+using ReactNative.Modules.Core;
+using Windows.Networking.Connectivity;
+
+namespace ReactNativeCommunity.NetInfo
+{
+    /// <summary>
+    /// Module that monitors and provides information about the connectivity
+    /// state of the device.
+    /// </summary>
+    public class RNCNetInfoModule : ReactContextNativeModuleBase, ILifecycleEventListener
+    {
+        // These constants need to match the strings defined in types.ts
+        private const string CONNECTION_TYPE_CELLULAR = "cellular";
+        private const string CONNECTION_TYPE_ETHERNET = "ethernet";
+        private const string CONNECTION_TYPE_NONE = "none";
+        private const string CONNECTION_TYPE_UNKNOWN = "unknown";
+        private const string CONNECTION_TYPE_WIFI = "wifi";
+
+        private const string CELLULAR_GENERATION_2G = "2g";
+        private const string CELLULAR_GENERATION_3G = "3g";
+        private const string CELLULAR_GENERATION_4G = "4g";
+        private const string CELLULAR_GENERATION_NONE = null;
+        private const string CELLULAR_GENERATION_UNKNOWN = null;
+
+        private readonly INetworkInformation _networkInfo;
+
+        /// <summary>
+        /// Instantiates the <see cref="RNCNetInfoModule"/>.
+        /// </summary>
+        /// <param name="reactContext">The React context.</param>
+        public RNCNetInfoModule(ReactContext reactContext)
+            : this(new DefaultNetworkInformation(), reactContext)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates the <see cref="RNCNetInfoModule"/>.
+        /// </summary>
+        /// <param name="networkInfo">The network information.</param>
+        /// <param name="reactContext">The React context.</param>
+        public RNCNetInfoModule(INetworkInformation networkInfo, ReactContext reactContext)
+            : base(reactContext)
+        {
+            _networkInfo = networkInfo;
+        }
+
+        /// <summary>
+        /// Gets the name of the native module.
+        /// </summary>
+        public override string Name
+        {
+            get
+            {
+                return "RNCNetInfo";
+            }
+        }
+
+        /// <summary>
+        /// Gets the current connectivity state of the app.
+        /// </summary>
+        /// <param name="promise">A promise to resolve the request.</param>
+        [ReactMethod]
+        public void getCurrentState(IPromise promise)
+        {
+            promise.Resolve(CreateConnectivityEventMap());
+        }
+
+        /// <summary>
+        /// Called when the application host is destroyed.
+        /// </summary>
+        public void OnDestroy()
+        {
+        }
+
+        /// <summary>
+        /// Called when the application host is resumed.
+        /// </summary>
+        public void OnResume()
+        {
+            _networkInfo.Start();
+            _networkInfo.NetworkStatusChanged += OnStatusChanged;
+        }
+
+        /// <summary>
+        /// Called when the application host is suspended.
+        /// </summary>
+        public void OnSuspend()
+        {
+            _networkInfo.NetworkStatusChanged -= OnStatusChanged;
+            _networkInfo.Stop();
+        }
+
+        /// <summary>
+        /// Called when the React instance is initialized.
+        /// </summary>
+        public override void Initialize()
+        {
+            Context.AddLifecycleEventListener(this);
+        }
+
+        private JObject CreateConnectivityEventMap()
+        {
+            var eventMap = new JObject();
+
+            // Add the connection type information
+            var type = GetConnectivityType();
+            eventMap.Add("type", type);
+
+            // Add the connection state information
+            var isConnected = GetIsConnected();
+            eventMap.Add("isConnected", isConnected);
+
+            // Add the details, if there are any
+            JObject details = null;
+            if (isConnected)
+            {
+                details = new JObject();
+
+                var isConnectionExpensive = GetIsConnectionExpensive();
+                details.Add("isConnectionExpensive", isConnectionExpensive);
+
+                if (type == CONNECTION_TYPE_CELLULAR)
+                {
+                    var cellularGeneration = GetCellularGeneration();
+                    details.Add("cellularGeneration", cellularGeneration);
+                }
+            }
+            eventMap.Add("details", details);
+
+            return eventMap;
+        }
+
+        private string GetConnectivityType()
+        {
+            var profile = _networkInfo.GetInternetConnectionProfile();
+            if (profile == null)
+            {
+                return CONNECTION_TYPE_NONE;
+            }
+
+            switch (profile.ConnectionType)
+            {
+                case NetworkConnectionType.Unknown:
+                    return CONNECTION_TYPE_UNKNOWN;
+                case NetworkConnectionType.None:
+                    return CONNECTION_TYPE_NONE;
+                case NetworkConnectionType.Cellular:
+                    return CONNECTION_TYPE_CELLULAR;
+                case NetworkConnectionType.Ethernet:
+                    return CONNECTION_TYPE_ETHERNET;
+                case NetworkConnectionType.Wifi:
+                    return CONNECTION_TYPE_WIFI;
+                default:
+                    return CONNECTION_TYPE_UNKNOWN;
+            }
+        }
+
+        private string GetCellularGeneration()
+        {
+            var profile = _networkInfo.GetInternetConnectionProfile();
+            if (profile == null)
+            {
+                return CELLULAR_GENERATION_NONE;
+            }
+
+            switch (profile.CellularGeneration)
+            {
+                case CellularGeneration.Unknown:
+                    return CELLULAR_GENERATION_UNKNOWN;
+                case CellularGeneration.None:
+                    return CELLULAR_GENERATION_NONE;
+                case CellularGeneration.Generation2:
+                    return CELLULAR_GENERATION_2G;
+                case CellularGeneration.Generation3:
+                    return CELLULAR_GENERATION_3G;
+                case CellularGeneration.Generation4:
+                    return CELLULAR_GENERATION_4G;
+                default:
+                    return CELLULAR_GENERATION_UNKNOWN;
+            }
+        }
+
+        private bool GetIsConnected()
+        {
+            var profile = _networkInfo.GetInternetConnectionProfile();
+            return profile != null && profile.ConnectivityLevel != NetworkConnectivityLevel.None;
+        }
+
+        private bool GetIsConnectionExpensive()
+        {
+            var profile = _networkInfo.GetInternetConnectionProfile();
+            if (profile == null)
+            {
+                return false;
+            }
+
+            var connectionCost = profile.ConnectionCost;
+            return connectionCost == NetworkCostType.Fixed || connectionCost == NetworkCostType.Variable;
+        }
+
+        private void OnStatusChanged(object ignored)
+        {
+            var connectivity = CreateConnectivityEventMap();
+            Context.GetJavaScriptModule<RCTDeviceEventEmitter>()
+                .emit("netInfo.networkStatusDidChange", CreateConnectivityEventMap());
+        }
+    }
+}

--- a/windows/RNCNetInfo/RNCNetInfoPackage.cs
+++ b/windows/RNCNetInfo/RNCNetInfoPackage.cs
@@ -1,0 +1,53 @@
+using ReactNative.Bridge;
+using ReactNative.Modules.Core;
+using ReactNative.UIManager;
+using System;
+using System.Collections.Generic;
+
+namespace ReactNativeCommunity.NetInfo
+{
+    /// <summary>
+    /// Package defining core framework modules (e.g., <see cref="UIManagerModule"/>). 
+    /// It should be used for modules that require special integration with
+    /// other framework parts (e.g., with the list of packages to load view
+    /// managers from).
+    /// </summary>
+    public class RNCNetInfoPackage : IReactPackage
+    {
+        /// <summary>
+        /// Creates the list of native modules to register with the react
+        /// instance.
+        /// </summary>
+        /// <param name="reactContext">The react application context.</param>
+        /// <returns>The list of native modules.</returns>
+        public IReadOnlyList<INativeModule> CreateNativeModules(ReactContext reactContext)
+        {
+            return new List<INativeModule>
+            {
+                new RNCNetInfoModule(reactContext),
+            };
+        }
+
+        /// <summary>
+        /// Creates the list of JavaScript modules to register with the 
+        /// react instance.
+        /// </summary>
+        /// <returns>The list of JavaScript modules.</returns>
+        public IReadOnlyList<Type> CreateJavaScriptModulesConfig()
+        {
+            return new List<Type>(0);
+        }
+
+        /// <summary>
+        /// Creates the list of view managers that should be registered with
+        /// the <see cref="UIManagerModule"/>.
+        /// </summary>
+        /// <param name="reactContext">The react application context.</param>
+        /// <returns>The list of view managers.</returns>
+        public IReadOnlyList<IViewManager> CreateViewManagers(
+            ReactContext reactContext)
+        {
+            return new List<IViewManager>(0);
+        }
+    }
+}


### PR DESCRIPTION
# Overview
This PR adds Windows as a supported platform.

I started by bringing over the code from the [react-native-windows](https://github.com/microsoft/react-native-windows/tree/0.57-stable/ReactWindows/ReactNative/Modules/NetInfo) repo and then I implemented the new features that have been added to this repo since it was extracted from the core of React Native.

# Test Plan
I tested this PR manually by adding it to the [ReactXP Sample Project](https://github.com/microsoft/reactxp/tree/master/samples/RXPTest) and combining it with a WIP PR I currently have open at https://github.com/microsoft/reactxp/pull/1092

I have not added any automated tests with this PR because I have struggled to get this repo's automated tests to run on Windows.