### PR TITLE
Do not require es6 or downlevel-iterators TS flag

### DIFF
--- a/src/internal/deprecatedSubscriptions.ts
+++ b/src/internal/deprecatedSubscriptions.ts
@@ -19,10 +19,9 @@ let _latestState: DeprecatedTypes.NetInfoData | null = null;
 let _isListening = false;
 
 function _listenerHandler(state: Types.NetInfoState): void {
-  _latestState = DeprecatedUtils.convertState(state);
-  for (let handler of _subscriptions) {
-    handler(_latestState);
-  }
+  const convertedState = DeprecatedUtils.convertState(state);
+  _latestState = convertedState;
+  _subscriptions.forEach((handler): void => handler(convertedState));
 }
 
 export function add(handler: DeprecatedTypes.ChangeHandler): void {

--- a/src/internal/subscriptions.ts
+++ b/src/internal/subscriptions.ts
@@ -20,9 +20,7 @@ let _nativeEventSubscription: NativeEventSubscription | null = null;
 
 function _listenerHandler(state: Types.NetInfoState): void {
   _latestState = state;
-  for (let handler of _subscriptions) {
-    handler(_latestState);
-  }
+  _subscriptions.forEach((handler): void => handler(state));
 }
 
 export function add(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "include": ["src/**/*.ts", "example/**/*.ts", "example/**/*.tsx"],
   "compilerOptions": {
-    "target": "es6",
-    "module": "es6",
+    "target": "es5",
+    "module": "commonjs",
     "strict": true,
-    "downlevelIteration": true,
     "moduleResolution": "node",
     "lib": ["es2015", "es2016", "esnext"],
     "jsx": "react-native"


### PR DESCRIPTION
# Overview
This is a simple fix for #100 which removed the need for `es6` or the downlevel-iterators TypeScript flag.

Fixes #100.

# Test Plan
Tests should pass.

cc @mikehardy 
