### PR TITLE
Update jest mock guide to match V3 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,7 @@ You should then add the following to your Jest setup file to mock the NetInfo Na
 import { NativeModules } from 'react-native';
 
 NativeModules.RNCNetInfo = {
-  getCurrentConnectivity: jest.fn(),
-  isConnectionMetered: jest.fn(),
+  getCurrentState: jest.fn(),
   addListener: jest.fn(),
   removeListeners: jest.fn()
 };


### PR DESCRIPTION
# Overview

It looks like the guide for what to mock in jest didn't get updated when the new V3 of the API landed. I've updated the `README.md`, according to the types in [src/internal/privateTypes.ts](https://github.com/react-native-community/react-native-netinfo/blob/master/src/internal/privateTypes.ts).

Let me know if it is not correct, or if there's anything else I need to change.