### PR TITLE
The NativeModules module does not have the RNCNetInfo property. When the NativeModules are exported, the getCurrentState method is used. In the following, the NetInfoNativeModule object is imported.

### DIFF
--- a/src/internal/nativeInterface.ts
+++ b/src/internal/nativeInterface.ts
@@ -10,8 +10,8 @@
 import {NativeEventEmitter, NativeModules} from 'react-native';
 import {NetInfoNativeModule} from './privateTypes';
 
-const RNCNetInfo: NetInfoNativeModule | undefined = NativeModules.RNCNetInfo;
-
+//const RNCNetInfo: NetInfoNativeModule | undefined = NativeModules.RNCNetInfo;
+const RNCNetInfo: NetInfoNativeModule | undefined = NativeModules.NetInfo;
 // Produce an error if we don't have the native module
 if (!RNCNetInfo) {
   throw new Error(`@react-native-community/netinfo: NativeModule.RNCNetInfo is null. To fix this issue try these steps:
@@ -31,6 +31,7 @@ If none of these fix the issue, please open an issue on the Github repository: h
  */
 let nativeEventEmitter: NativeEventEmitter | null = null;
 export default {
+  ...NetInfoNativeModule,
   ...RNCNetInfo,
   get eventEmitter(): NativeEventEmitter {
     if (!nativeEventEmitter) {


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
