### PR TITLE
Add a null check for mCellularGeneration to avoid a potential crash

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -98,7 +98,7 @@ abstract class ConnectivityReceiver {
                     ConnectivityManagerCompat.isActiveNetworkMetered(getConnectivityManager());
             details.putBoolean("isConnectionExpensive", isConnectionExpensive);
 
-            if (mConnectionType.equals(ConnectionType.CELLULAR)) {
+            if (mConnectionType.equals(ConnectionType.CELLULAR) && mCellularGeneration != null) {
                 details.putString("cellularGeneration", mCellularGeneration.label);
             }
         }


### PR DESCRIPTION
# Overview

Fixes a crash when trying to access a `null` cellular generation value:

```
Fatal Exception: java.lang.NullPointerException: Attempt to read from field 'java.lang.String com.reactnativecommunity.netinfo.types.CellularGeneration.label' on a null object reference
```