### PR TITLE
Support IPv4/6 on iOS

### DIFF
--- a/ios/RNCConnectionStateWatcher.m
+++ b/ios/RNCConnectionStateWatcher.m
@@ -57,7 +57,6 @@ static void RNCReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
 {
     RNCConnectionStateWatcher *self = (__bridge id)info;
     [self update:flags];
-
 }
 
 - (void)update:(SCNetworkReachabilityFlags)flags

--- a/ios/RNCConnectionStateWatcher.m
+++ b/ios/RNCConnectionStateWatcher.m
@@ -7,6 +7,7 @@
 
 #import "RNCConnectionStateWatcher.h"
 #import <SystemConfiguration/SystemConfiguration.h>
+#import <netinet/in.h>
 
 @interface RNCConnectionStateWatcher () <NSURLSessionDataDelegate>
 
@@ -56,7 +57,7 @@ static void RNCReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
 {
     RNCConnectionStateWatcher *self = (__bridge id)info;
     [self update:flags];
-    
+
 }
 
 - (void)update:(SCNetworkReachabilityFlags)flags
@@ -71,7 +72,7 @@ static void RNCReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
 {
     if (![state isEqualToConnectionState:_state]) {
         _state = state;
-        
+
         [self updateDelegate];
     }
 }
@@ -85,11 +86,22 @@ static void RNCReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
 
 - (SCNetworkReachabilityRef)createReachabilityRef
 {
-    SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, "apple.com");
+    struct sockaddr_in zeroAddress;
+    bzero(&zeroAddress, sizeof(zeroAddress));
+    zeroAddress.sin_len = sizeof(zeroAddress);
+    zeroAddress.sin_family = AF_INET;
+
+    SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr *) &zeroAddress);
     // Set the callback, setting our "self" as the info so we can get a reference in the callback
     SCNetworkReachabilityContext context = { 0, ( __bridge void *)self, NULL, NULL, NULL };
     SCNetworkReachabilitySetCallback(reachability, RNCReachabilityCallback, &context);
     SCNetworkReachabilityScheduleWithRunLoop(reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+
+    // Set the state the first time
+    SCNetworkReachabilityFlags flags;
+    SCNetworkReachabilityGetFlags(reachability, &flags);
+    [self update:flags];
+
     return reachability;
 }
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
#### Summary
At Mattermost we received a lot of reports about Internet Reachability not working on LTE networks that assign IPv6 addresses, the current implementation uses a hostname based to test for reachability and the hostname "apple.com" does not have IPv6 addresses causing the check to fail.

With this PR we implemented the Internet connectivity test exposed in [this example](https://developer.apple.com/library/archive/samplecode/Reachability/Listings/ReadMe_md.html#//apple_ref/doc/uid/DTS40007324-ReadMe_md-DontLinkElementID_11)

it uses a different mechanism.

```
- reachabilityWithHostName and SCNetworkReachabilityCreateWithName:  Internally, this API works be resolving the host name to a set of IP addresses (this can be any combination of IPv4 and IPv6 addresses) and establishing separate monitors on all available addresses.
```
:point_up: for some reason it seems that is does not work great with IPv6 as the hostname does not have IPv6 addresses assigned

--------

With the changes made we are now using this:

```
- reachabilityForInternetConnection:  This monitors the address 0.0.0.0, which reachability treats as a special token that causes it to actually monitor the general routing status of the device, both IPv4 and IPv6.
```

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

The changes in code only affect iOS and there should not be any changes in behavior other than detecting internet connectivity on IPv6 networks