### PR TITLE
fix(iOS): correct tag so CocoaPods can clone the repo

### DIFF
--- a/react-native-netinfo.podspec
+++ b/react-native-netinfo.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platforms    = { :ios => "9.0", :tvos => "9.2" }
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
# Overview

CocoaPods will fail if `react-native-netinfo` is imported using `:podspec`:

```ruby
pod 'react-native-netinfo', :podspec => 'node_modules/@react-native-community/netinfo/react-native-netinfo.podspec'
```

# Test Plan

Modify `Podfile` to use `:podspec` instead of `:path`, then make sure `pod install` succeeds.