### PR TITLE
fix: Do not include examples in the NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 __tests__
+example/


### PR DESCRIPTION
# Overview
Removes the `examples` folder from the NPM package.

Fixes #175