### PR TITLE
Add gradle backward-compatibility with AndroidX

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,48 @@ or npm:
 npm install --save @react-native-community/netinfo
 ```
 
+#### Using React Native >= 0.60
+Linking the package manually is not required anymore with [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
+
+- **iOS Platform:**
+
+  `$ cd ios && pod install && cd ..` # CocoaPods on iOS needs this extra step
+
+- **Android Platform with Android Support:**
+
+  Using [Jetifier tool](https://github.com/mikehardy/jetifier) for backward-compatibility.
+
+  Modify your **android/build.gradle** configuration:
+  ```
+  buildscript {
+    ext {
+      buildToolsVersion = "28.0.3"
+      minSdkVersion = 16
+      compileSdkVersion = 28
+      targetSdkVersion = 28
+      # Only using Android Support libraries
+      supportLibVersion = "28.0.0"
+    }
+  ```
+
+- **Android Platform with AndroidX:**
+
+  Modify your **android/build.gradle** configuration:
+  ```
+  buildscript {
+    ext {
+      buildToolsVersion = "28.0.3"
+      minSdkVersion = 16
+      compileSdkVersion = 28
+      targetSdkVersion = 28
+      # Remove 'supportLibVersion' property and put specific versions for AndroidX libraries
+      androidXCore = "1.0.2"
+      // Put here other AndroidX dependencies
+    }
+  ```
+
+#### Using React Native < 0.60
+
 You then need to link the native parts of the library for the platforms you are using. The easiest way to link the library is using the CLI tool by running this command from the root of your project:
 
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,10 @@ spotless {
   }
 }
 
+def getExtOrInitialValue(name, initialValue) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : initialValue
+}
+
 def getExtOrDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['ReactNativeNetInfo_' + name]
 }
@@ -66,4 +70,17 @@ repositories {
 dependencies {
   //noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
+
+  def supportLibVersion = getExtOrInitialValue('supportLibVersion', getExtOrInitialValue('supportVersion', null))
+  def androidXVersion = getExtOrInitialValue('androidXVersion', null)
+  if (supportLibVersion && androidXVersion == null) {
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+  } else {
+    def defaultAndroidXVersion = "1.+"
+    if (androidXVersion == null) {
+      androidXVersion = defaultAndroidXVersion
+    }
+    def androidXCore = getExtOrInitialValue('androidXCore', androidXVersion)
+    implementation "androidx.core:core:$androidXCore"
+  }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,5 +2,3 @@ ReactNativeNetInfo_compileSdkVersion=28
 ReactNativeNetInfo_buildToolsVersion=28.0.3
 ReactNativeNetInfo_targetSdkVersion=27
 ReactNativeNetInfo_minSdkVersion=16
-android.useAndroidX=true
-android.enableJetifier=true

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -155,7 +155,6 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation project(':react-native-netinfo')
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     androidTestImplementation('com.wix:detox:+') { transitive = true }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,8 @@ buildscript {
     minSdkVersion = 18
     compileSdkVersion = 28
     targetSdkVersion = 28
-    supportLibVersion = "28.0.0"
+    androidXVersion = "1.+" // Default AndroidX dependency
+    androidXCore = "1.0.2"
 
     // e2e
     kotlinVersion = '1.3.0'

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -24,3 +24,6 @@ EXAMPLE_APP_STORE_FILE=release.keystore
 EXAMPLE_APP_KEY_ALIAS=androiddebugkey
 EXAMPLE_APP_STORE_PASSWORD=android
 EXAMPLE_APP_KEY_PASSWORD=android
+
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
# Overview
The idea with this PR is to remove breaking changes supporting AndroidX, as we can see here: https://github.com/react-native-community/react-native-netinfo/issues/191
Please let me know the **commands** to verify these changes from Android 👍 

# Test Plan
If you want I can modify the README to include the instructions :)
