### PR TITLE
fix(tvOS): Do not import CoreTelephony on tvOS

### DIFF
--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -10,7 +10,10 @@
 
 #include <ifaddrs.h>
 #include <arpa/inet.h>
+
+#if !TARGET_OS_TV
 @import CoreTelephony;
+#endif
 
 #import <React/RCTAssert.h>
 #import <React/RCTBridge.h>


### PR DESCRIPTION
# Overview
0aa2486cc55503d9ff4c30a099285188307e36e0 missed a tvOS check, this PR fixes that


# Test Plan
Build for tvOS
