### PR TITLE
feat: Added 'subnet' to wifi details [Android & iOS]

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The `details` value depends on the `type` value.
 | `ssid`                  | Android               | `string`  | The SSID of the network. May not be present, `null`, or an empty string if it cannot be determined.                        |
 | `strength`              | Android               | `number`  | An integer number from `0` to `5` for the signal strength. May not be present if the signal strength cannot be determined. |
 | `ipAddress`             | Android, iOS          | `string`  | The external IP address. Can be in IPv4 or IPv6 format. May not be present if it cannot be determined.                     |
+| `subnet`                | Android, iOS          | `string`  | The subnet mask in IPv4 format. May not be present if it cannot be determined.                                             |
 
 ##### `type` is `cellular`
 

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -21,6 +21,8 @@ import com.reactnativecommunity.netinfo.types.CellularGeneration;
 import com.reactnativecommunity.netinfo.types.ConnectionType;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -154,6 +156,20 @@ abstract class ConnectivityReceiver {
                         InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
                         String ipAddress = inetAddress.getHostAddress();
                         details.putString("ipAddress", ipAddress);
+                    } catch (Exception e) {
+                        // Ignore errors
+                    }
+
+                    // Get the subnet mask
+                    try {
+                        byte[] ipAddressByteArray =
+                                BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
+                        NetInfoUtils.reverseByteArray(ipAddressByteArray);
+                        InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
+                        NetworkInterface netAddress = NetworkInterface.getByInetAddress(inetAddress);
+                        int mask = 0xffffffff << (32 - netAddress.getInterfaceAddresses().get(1).getNetworkPrefixLength());
+                        String subnet = String.format("%d.%d.%d.%d", (mask >> 24 & 0xff), (mask >> 16 & 0xff), (mask >> 8 & 0xff), (mask & 0xff));
+                        details.putString("subnet", subnet);
                     } catch (Exception e) {
                         // Ignore errors
                     }


### PR DESCRIPTION
# Overview
I've added in the **subnet mask** to the `details` object on WiFi connection both on Android and iOS.


# Test Plan
Screenshot:
![wifidetails](https://user-images.githubusercontent.com/44206249/65788246-f24dc500-e15a-11e9-87c9-466dbbf7bc96.PNG)
