### PR TITLE
docs: Manual Linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ project(':react-native-community-netinfo').projectDir = new File(rootProject.pro
 ```groovy
 dependencies {
    ...
-   implementation project(':react-native-community-netinfo')
+   implementation project(':@react-native-community_netinfo')
 }
 ```
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. --> When manually linking the library linking should be fixed in the build.gradle file.
<!-- Help us understand your motivation by explaining why you decided to make this change -->
