### PR TITLE
fix(iOS): race condition when releasing resources

### DIFF
--- a/ios/RNCConnectionStateWatcher.m
+++ b/ios/RNCConnectionStateWatcher.m
@@ -40,6 +40,7 @@
     if (self.reachabilityRef != nil) {
         SCNetworkReachabilityUnscheduleFromRunLoop(self.reachabilityRef, CFRunLoopGetMain(), kCFRunLoopCommonModes);
         CFRelease(self.reachabilityRef);
+        self.reachabilityRef = nil;
     }
 }
 


### PR DESCRIPTION
When React Native is invalidated on a background thread, we can get
a use-after-free crash because RNCConnectionStateWatcher may be
deallocated while the callback is called.

Addresses #206.

# Test Plan
This is a bit hard to test since it involves setting up the right conditions for
this to trigger. I'm open to any suggestions here.