### PR TITLE
Fix build.gradle react-native dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,6 +62,10 @@ android {
 }
 
 repositories {
+  maven {
+    // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+    url "$rootDir/../node_modules/react-native/android"
+  }
   google()
   jcenter()
   mavenCentral()
@@ -69,7 +73,7 @@ repositories {
 
 dependencies {
   //noinspection GradleDynamicVersion
-  api 'com.facebook.react:react-native:+'
+  implementation 'com.facebook.react:react-native:+'
 
   def supportLibVersion = getExtOrInitialValue('supportLibVersion', getExtOrInitialValue('supportVersion', null))
   def androidXVersion = getExtOrInitialValue('androidXVersion', null)


### PR DESCRIPTION
# Overview

`build.gradle` was missing a maven reference to correctly resolve the locally installed `react-native` dependency. This had the effect that it would resolve version `0.20.1` from [Maven Central](https://mvnrepository.com/artifact/com.facebook.react/react-native) (the last version published in Feb 2016).

Also, `react-native` was incorrectly declared as an `api`-type dependency - That is not required. Using a regular `implementation`-type dependency should be enough, which is used by other RN library projects as well. App projects contain their own reference for `react-native`.

Fixes #214
Closes #215

# Test Plan

1. Clone project
2. `cd android`
3. `gradlew build`

EDIT:
Instead of building from command line, the same issue can be seen by just opening the `android` folder with **Android Studio**. Previously, there would be a compilation error (due to an incorrectly resolved `react-native` version) - Now with these changes, it will build without issues.