### PR TITLE
fix(iOS): Method definition for 'dictionaryValue' not found

### DIFF
--- a/ios/RNCConnectionState.h
+++ b/ios/RNCConnectionState.h
@@ -28,9 +28,8 @@ static NSString *const RNCCellularGeneration4g = @"4g";
 - (instancetype)init;
 - (instancetype)initWithReachabilityFlags:(SCNetworkReachabilityFlags)flags;
 - (BOOL)isEqualToConnectionState:(RNCConnectionState *)otherState;
-- (NSDictionary *)dictionaryValue;
 
-@property (nonnull, nonatomic, strong, readonly) NSString *type;
+@property (nonatomic, strong, readonly) NSString *type;
 @property (nullable, nonatomic, strong, readonly) NSString *cellularGeneration;
 @property (nonatomic, readonly) BOOL connected;
 @property (nonatomic, readonly) BOOL expensive;


### PR DESCRIPTION
# Overview
Removes an unused method with missing definition.

# Test Plan
iOS compilation should not fail.