### PR TITLE
Use androidXCore together with supportLibVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,14 +77,14 @@ dependencies {
 
   def supportLibVersion = getExtOrInitialValue('supportLibVersion', getExtOrInitialValue('supportVersion', null))
   def androidXVersion = getExtOrInitialValue('androidXVersion', null)
-  if (supportLibVersion && androidXVersion == null) {
+  def androidXCore = getExtOrInitialValue('androidXCore', null)
+  if (supportLibVersion && androidXVersion == null && androidXCore == null) {
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
   } else {
     def defaultAndroidXVersion = "1.+"
-    if (androidXVersion == null) {
-      androidXVersion = defaultAndroidXVersion
+    if (androidXCore == null) {
+      androidXCore = androidXVersion == null ? defaultAndroidXVersion : androidXVersion
     }
-    def androidXCore = getExtOrInitialValue('androidXCore', androidXVersion)
     implementation "androidx.core:core:$androidXCore"
   }
 }


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

I followed the instructions of README that suggest to define a value to `androidXCore`. But when it's defined together with `supportLibVersion`, the conditional doesn't match to use the androidx.

I know that this sounds weird to use both definitions together, but this is the only solution as I'm using [@react-native-community/react-native-maps with androidx](https://github.com/react-native-community/react-native-maps/blob/master/lib/android/build.gradle#L20-L22) in my project.

For now, I resolved using the undocumented definition of `androidXVersion`, but it'll be good to have both setup options as it's kinda of a simple solution.


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

1 - Change the `android/build.gradle`
```groovy
buildscript {
  ext {
    buildToolsVersion = "28.0.3"
    minSdkVersion = 16
    compileSdkVersion = 28
    targetSdkVersion = 28
    // add these lines below
    androidXCore = "1.0.2"
    supportLibVersion = "1.1.0-rc01"
  }
```

2 - Run the project, it'll be build with androidx instead of android.support
