### PR TITLE
[feat/fix] Add ability to detect network reachability on FireOS devices

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/AmazonFireDeviceConnectivityPoller.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/AmazonFireDeviceConnectivityPoller.java
@@ -1,0 +1,170 @@
+package com.reactnativecommunity.netinfo;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.Handler;
+
+/**
+ * A component similar to ConnectivityReceiver (and its implementations) that goes through
+ * register/unregister cycles. It is only active on an Amazon Fire device (e.g. FireTV Stick). It
+ * will continuously issue an intent to FireOS to check for internet connectivity and listen to the
+ * response via broadcast receiver.
+ *
+ * <p>This is required since FireOs does not report network capabilities correctly
+ * (NetworkCapabilities.NET_CAPABILITY_VALIDATED is true when offline) even when the OS knows that
+ * the internet is not reachable.
+ *
+ * <p>The caller component is responsible to responding to callbacks of the device going online or
+ * offline.
+ */
+public class AmazonFireDeviceConnectivityPoller {
+    /** Intent action for triggering FireOS connectivity checking. */
+    private static final String ACTION_CONNECTIVITY_CHECK =
+            "com.amazon.tv.networkmonitor.CONNECTIVITY_CHECK";
+
+    /** Broadcast sent by NetMon FireOS component when the device cannot reach the internet. */
+    private static final String ACTION_INTERNET_DOWN = "com.amazon.tv.networkmonitor.INTERNET_DOWN";
+
+    /** Broadcast sent by NetMon FireOS component when the can reach the internet. */
+    private static final String ACTION_INTERNET_UP = "com.amazon.tv.networkmonitor.INTERNET_UP";
+
+    /** Interval (in milliseconds) of how often to check for connectivity. */
+    private static final long POLLING_INTERVAL_MS = 10 * 1000;
+
+    private final Receiver receiver = new Receiver();
+    private final Context context;
+    private final ConnectivityChangedCallback callback;
+
+    private final Runnable checker = new PollerTask();
+    private Handler handler;
+    private boolean pollerRunning = false;
+
+    /** Callback interface that will be invoked when internet connectivity status changes. */
+    public interface ConnectivityChangedCallback {
+        /**
+         * Called when internet connectivity status changes.
+         *
+         * @param isConnected
+         */
+        void onAmazonFireDeviceConnectivityChanged(boolean isConnected);
+    }
+
+    AmazonFireDeviceConnectivityPoller(Context context, ConnectivityChangedCallback callback) {
+        this.context = context;
+        this.callback = callback;
+    }
+
+    public void register() {
+        if (!isFireOsDevice()) {
+            return;
+        }
+
+        registerReceiver();
+        startPoller();
+    }
+
+    public void unregister() {
+        if (!isFireOsDevice()) {
+            return;
+        }
+
+        unregisterReceiver();
+        stopPoller();
+    }
+
+    private boolean isFireOsDevice() {
+        // https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
+        // https://developer.amazon.com/docs/fire-tablets/ft-specs-custom.html
+        return Build.MANUFACTURER.equals("Amazon")
+                && (Build.MODEL.startsWith("AF") || Build.MODEL.startsWith("KF"));
+    }
+
+    private void registerReceiver() {
+        if (receiver.registered) {
+            return;
+        }
+
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(ACTION_INTERNET_DOWN);
+        filter.addAction(ACTION_INTERNET_UP);
+        context.registerReceiver(receiver, filter);
+
+        receiver.registered = true;
+    }
+
+    private void startPoller() {
+        if (pollerRunning) {
+            return;
+        }
+
+        // NOTE: since this is usually called on the right thread, we construct
+        //       the handler here rather than in the constructor.
+        handler = new Handler();
+        pollerRunning = true;
+        handler.post(checker);
+
+        // NOTE: In the future, WorkManager or another approach to the polling task
+        //       would work better. For now though this is the simpler way to keep
+        //       checking for connectivity.
+    }
+
+    private void unregisterReceiver() {
+        if (!receiver.registered) {
+            return;
+        }
+
+        context.unregisterReceiver(receiver);
+        receiver.registered = false;
+    }
+
+    private void stopPoller() {
+        if (!pollerRunning) {
+            return;
+        }
+
+        pollerRunning = false;
+        handler.removeCallbacksAndMessages(null);
+        handler = null;
+    }
+
+    private class Receiver extends BroadcastReceiver {
+        boolean registered = false;
+
+        private Boolean lastIsConnected;
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent == null ? null : intent.getAction();
+            boolean isConnected;
+            if (ACTION_INTERNET_DOWN.equals(action)) {
+                isConnected = false;
+            } else if (ACTION_INTERNET_UP.equals(action)) {
+                isConnected = true;
+            } else {
+                return;
+            }
+
+            if (lastIsConnected == null || lastIsConnected != isConnected) {
+                lastIsConnected = isConnected;
+                callback.onAmazonFireDeviceConnectivityChanged(isConnected);
+            }
+        }
+    }
+
+    private class PollerTask implements Runnable {
+        @Override
+        public void run() {
+            if (!pollerRunning) {
+                return;
+            }
+
+            Intent checkIntent = new Intent(ACTION_CONNECTIVITY_CHECK);
+            context.sendBroadcast(checkIntent);
+
+            handler.postDelayed(checker, POLLING_INTERVAL_MS);
+        }
+    }
+}

--- a/android/src/main/java/com/reactnativecommunity/netinfo/AmazonFireDeviceConnectivityPoller.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/AmazonFireDeviceConnectivityPoller.java
@@ -71,8 +71,8 @@ public class AmazonFireDeviceConnectivityPoller {
             return;
         }
 
-        unregisterReceiver();
         stopPoller();
+        unregisterReceiver();
     }
 
     private boolean isFireOsDevice() {

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -11,6 +11,7 @@ import android.net.ConnectivityManager;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.telephony.TelephonyManager;
+
 import androidx.core.net.ConnectivityManagerCompat;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -36,6 +37,7 @@ abstract class ConnectivityReceiver {
     @Nonnull private ConnectionType mConnectionType = ConnectionType.UNKNOWN;
     @Nullable private CellularGeneration mCellularGeneration = null;
     private boolean mIsInternetReachable = false;
+    private Boolean mIsInternetReachableOverride;
 
     ConnectivityReceiver(ReactApplicationContext reactContext) {
         mReactContext = reactContext;
@@ -56,6 +58,15 @@ abstract class ConnectivityReceiver {
         promise.resolve(createConnectivityEventMap());
     }
 
+    public void setIsInternetReachableOverride(boolean isInternetReachableOverride) {
+        this.mIsInternetReachableOverride = isInternetReachableOverride;
+        updateConnectivity(mConnectionType, mCellularGeneration, mIsInternetReachable);
+    }
+
+    public void clearIsInternetReachableOverride() {
+        this.mIsInternetReachableOverride = null;
+    }
+
     ReactApplicationContext getReactContext() {
         return mReactContext;
     }
@@ -67,7 +78,11 @@ abstract class ConnectivityReceiver {
     void updateConnectivity(
             @Nonnull ConnectionType connectionType,
             @Nullable CellularGeneration cellularGeneration,
-            boolean isInternetReachable) {
+            boolean isInternetReachableRaw) {
+        boolean isInternetReachable = mIsInternetReachableOverride == null
+                ? isInternetReachableRaw
+                : mIsInternetReachableOverride;
+
         // It is possible to get multiple broadcasts for the same connectivity change, so we only
         // update and send an event when the connectivity has indeed changed.
         boolean connectionTypeChanged = connectionType != mConnectionType;

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -41,8 +41,8 @@ public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonF
 
     @Override
     public void onCatalystInstanceDestroy() {
-        mConnectivityReceiver.unregister();
         mAmazonConnectivityChecker.unregister();
+        mConnectivityReceiver.unregister();
     }
 
     @Override

--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetInfoModule.java
@@ -15,10 +15,11 @@ import com.facebook.react.module.annotations.ReactModule;
 
 /** Module that monitors and provides information about the connectivity state of the device. */
 @ReactModule(name = NetInfoModule.NAME)
-public class NetInfoModule extends ReactContextBaseJavaModule {
+public class NetInfoModule extends ReactContextBaseJavaModule implements AmazonFireDeviceConnectivityPoller.ConnectivityChangedCallback {
     public static final String NAME = "RNCNetInfo";
 
     private final ConnectivityReceiver mConnectivityReceiver;
+    private final AmazonFireDeviceConnectivityPoller mAmazonConnectivityChecker;
 
     public NetInfoModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -28,16 +29,20 @@ public class NetInfoModule extends ReactContextBaseJavaModule {
         } else {
             mConnectivityReceiver = new BroadcastReceiverConnectivityReceiver(reactContext);
         }
+
+        mAmazonConnectivityChecker = new AmazonFireDeviceConnectivityPoller(reactContext, this);
     }
 
     @Override
     public void initialize() {
         mConnectivityReceiver.register();
+        mAmazonConnectivityChecker.register();
     }
 
     @Override
     public void onCatalystInstanceDestroy() {
         mConnectivityReceiver.unregister();
+        mAmazonConnectivityChecker.unregister();
     }
 
     @Override
@@ -48,5 +53,10 @@ public class NetInfoModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void getCurrentState(Promise promise) {
         mConnectivityReceiver.getCurrentState(promise);
+    }
+
+    @Override
+    public void onAmazonFireDeviceConnectivityChanged(boolean isConnected) {
+        mConnectivityReceiver.setIsInternetReachableOverride(isConnected);
     }
 }


### PR DESCRIPTION
# Overview
Looks like FireOS does not correctly report capabilities of the default network correctly, reporting a validated state when the internet is not actually reachable. After much experimentation on our project we were able to nail down the actions and broadcasts the OS uses to perform connectivity checks. While these are undocumented by Amazon, they have been in wide use for a while and have been presented as a side note in some presentation slides from Amazon.

This implementation will detect if the device in use is a FireOS device and only enable the extra checks if so. The data received from FireOS will override the mIsInternetReachable in ConnectivityReceiver instead of replacing it, allowing for other overrides to be done in a similar way later on for other platforms that do not use NetworkCapabilities correctly.

# Test Plan
- Make sure tests pass
- Ensure non FireOS devices correctly report connectivity/reachability
- Ensure FireOS devices correctly report connectivity/reachability