### PR TITLE
fix(iOS): CNCopySupportedInterfaces() isn't supported on tvOS (#258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ The `details` value depends on the `type` value.
 
 `details` has these properties:
 
-| Property                | Platform              | Type      | Description                                                                                                                |
-| ----------------------- | --------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `isConnectionExpensive` | Android, iOS, Windows | `boolean` | If the network connection is considered "expensive". This could be in either energy or monetary terms.                     |
-| `ssid`                  | Android, iOS          | `string`  | The SSID of the network. May not be present, `null`, or an empty string if it cannot be determined. **On iOS, make sure your app meets at least one of the [following requirements](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo?language=objc#discussion)**.             |
-| `strength`              | Android               | `number`  | An integer number from `0` to `5` for the signal strength. May not be present if the signal strength cannot be determined. |
-| `ipAddress`             | Android, iOS          | `string`  | The external IP address. Can be in IPv4 or IPv6 format. May not be present if it cannot be determined.                     |
-| `subnet`                | Android, iOS          | `string`  | The subnet mask in IPv4 format. May not be present if it cannot be determined.                                             |
+| Property                | Platform                | Type      | Description                                                                                                                |
+| ----------------------- | ----------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `isConnectionExpensive` | Android, iOS, Windows   | `boolean` | If the network connection is considered "expensive". This could be in either energy or monetary terms.                     |
+| `ssid`                  | Android, iOS (not tvOS) | `string`  | The SSID of the network. May not be present, `null`, or an empty string if it cannot be determined. **On iOS, make sure your app meets at least one of the [following requirements](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo?language=objc#discussion)**.             |
+| `strength`              | Android                 | `number`  | An integer number from `0` to `5` for the signal strength. May not be present if the signal strength cannot be determined. |
+| `ipAddress`             | Android, iOS            | `string`  | The external IP address. Can be in IPv4 or IPv6 format. May not be present if it cannot be determined.                     |
+| `subnet`                | Android, iOS            | `string`  | The subnet mask in IPv4 format. May not be present if it cannot be determined.                                             |
 
 ##### `type` is `cellular`
 

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -114,7 +114,9 @@ RCT_EXPORT_METHOD(getCurrentState:(RCTPromiseResolveBlock)resolve
     ) {
       details[@"ipAddress"] = [self ipAddress] ?: NSNull.null;
       details[@"subnet"] = [self subnet] ?: NSNull.null;
+#if !TARGET_OS_TV
       details[@"ssid"] = [self ssid] ?: NSNull.null;
+#endif
     }
   }
   
@@ -204,6 +206,7 @@ RCT_EXPORT_METHOD(getCurrentState:(RCTPromiseResolveBlock)resolve
   return subnet;
 }
 
+#if !TARGET_OS_TV
 - (NSString *)ssid
 {
   NSArray *interfaceNames = CFBridgingRelease(CNCopySupportedInterfaces());
@@ -221,5 +224,6 @@ RCT_EXPORT_METHOD(getCurrentState:(RCTPromiseResolveBlock)resolve
   }
   return SSID;
 }
+#endif
 
 @end


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Fixes #258 
