### PR TITLE
Issue/remove default config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ export function addEventListener(
  * @returns The connection state.
  */
 export function useNetInfo(
-  configuration: Partial<Types.NetInfoConfiguration>,
+  configuration?: Partial<Types.NetInfoConfiguration>,
 ): Types.NetInfoState {
   if (configuration) {
     configure(configuration);

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ export function addEventListener(
  * @returns The connection state.
  */
 export function useNetInfo(
-  configuration: Partial<Types.NetInfoConfiguration> = {},
+  configuration: Partial<Types.NetInfoConfiguration>,
 ): Types.NetInfoState {
   if (configuration) {
     configure(configuration);

--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -81,29 +81,25 @@ export default class InternetReachability {
           }
         },
       )
-      .then(
-        (result): void => {
-          if (result !== 'canceled') {
-            this._setIsInternetReachable(result);
-            const nextTimeoutInterval = this._isInternetReachable
-              ? this._configuration.reachabilityLongTimeout
-              : this._configuration.reachabilityShortTimeout;
-            this._currentTimeoutHandle = setTimeout(
-              this._checkInternetReachability,
-              nextTimeoutInterval,
-            );
-          }
-        },
-      )
-      .catch(
-        (): void => {
-          this._setIsInternetReachable(false);
+      .then((result): void => {
+        if (result !== 'canceled') {
+          this._setIsInternetReachable(result);
+          const nextTimeoutInterval = this._isInternetReachable
+            ? this._configuration.reachabilityLongTimeout
+            : this._configuration.reachabilityShortTimeout;
           this._currentTimeoutHandle = setTimeout(
             this._checkInternetReachability,
-            this._configuration.reachabilityShortTimeout,
+            nextTimeoutInterval,
           );
-        },
-      );
+        }
+      })
+      .catch((): void => {
+        this._setIsInternetReachable(false);
+        this._currentTimeoutHandle = setTimeout(
+          this._checkInternetReachability,
+          this._configuration.reachabilityShortTimeout,
+        );
+      });
 
     return {
       promise,


### PR DESCRIPTION
# Overview
Fixes issue described in #262.

`useNetInfo` is broken on multiple calls (which happens when components re-render).

The `configuration` is defaulted to `{}` and `configure` is always called. The call to `configure` then creates a new `State` instance. The `addEventListener` is _only_ called on the first time and the listener is not re-added on subsequent calls.

Overall I don't see how passing a `configuration` param is doable here as any attempt to add an event listener results in a re-render. I have changed it to not have a default value so it can work as it did before. If you do pass in a configuration param then you'll need to add a listener separately, I guess?

# Test Plan
I couldn't run the test suite as I got the following error

```bash
> @react-native-community/netinfo@5.0.0 test:jest /Users/lonnykapelushnik/Development/react-native-netinfo
> jest "/src/"

 FAIL  src/__tests__/fetch.ts
  ● Test suite failed to run

    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    src/internal/internetReachability.ts:91:13 - error TS2322: Type 'Timeout' is not assignable to type 'number'.

    91             this._currentTimeoutHandle = setTimeout(
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
    src/internal/internetReachability.ts:101:11 - error TS2322: Type 'Timeout' is not assignable to type 'number'.

    101           this._currentTimeoutHandle = setTimeout(
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~

 FAIL  src/__tests__/eventListenerCallbacks.ts
  ● Test suite failed to run

    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    src/internal/internetReachability.ts:91:13 - error TS2322: Type 'Timeout' is not assignable to type 'number'.

    91             this._currentTimeoutHandle = setTimeout(
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
    src/internal/internetReachability.ts:101:11 - error TS2322: Type 'Timeout' is not assignable to type 'number'.

    101           this._currentTimeoutHandle = setTimeout(
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~

Test Suites: 2 failed, 2 total
Tests:       0 total
Snapshots:   0 total
Time:        7.64s
```