### PR TITLE
fix(android): Handle invalid networks in network listener

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/NetworkCallbackConnectivityReceiver.java
@@ -78,6 +78,8 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
         }
 
         if (mNetwork != null) {
+            // This may return null per API docs, and is deprecated, but for older APIs (< VERSION_CODES.P)
+            // we need it to test for suspended internet
             networkInfo = getConnectivityManager().getNetworkInfo(mNetwork);
         }
 
@@ -85,7 +87,7 @@ class NetworkCallbackConnectivityReceiver extends ConnectivityReceiver {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             isInternetSuspended = !mNetworkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED);
         } else {
-            if (mNetwork != null) {
+            if (mNetwork != null && networkInfo != null) {
                 NetworkInfo.DetailedState detailedConnectionState = networkInfo.getDetailedState();
                 if (!detailedConnectionState.equals(NetworkInfo.DetailedState.CONNECTED)) {
                     isInternetSuspended = true;


### PR DESCRIPTION
# Overview

This fixes #285 - a null pointer possible in the recent fix for cell->airplane connectivity handling in Android, PR #265 from @lfalkner 

That PR is great but there appears to be a subtle interaction between the older deprecated synchronous APIs in combo with the async connection change listener

The API that returns an unexpected null to the code in #265 is part of the fallback code, and it's deprecated because according to the [Android API docs the synchronous ConnectionManager APIs don't operate in order and thus state might be incoherent (!?)](https://developer.android.com/reference/android/net/NetworkInfo.html) while the arguments provided in the callback methods (which is the main codepath in #265) are asserted to be coherent and so wouldn't suffer this.

So I'm guessing that on lower APIs, *sometimes*, the callback method is called with a network that is valid, but by the time the callback runs and you get to interrogating it about suspended status the network is no longer valid so the NetworkInfo is null [per the API docs return value text here](https://developer.android.com/reference/android/net/ConnectivityManager#getNetworkInfo(android.net.Network))

And because of all of that @javadi69 and I got the stack trace mentioned in #285

The only part of this I'm not 100% on is that we may leave "isInternetSuspended" in an incorrect state by just leaving that variable as 'false' despite having an invalid network. But I'm not sure what to do at that point, and I'd assume the callback will be triggered again resetting connectivity status entirely as part of whatever is happening on the device to cause a network to be invalidated (like if a VPN goes away I guess).

# Test Plan

I think adding a null check in response to a stack trace with a NullPointerException is fairly self-explanatory but I'm going to patch-package this in to my work project immediately and you can let it marinate and ask me later if you like pre-merge :-)