### PR TITLE
fix: Correct reachability timeouts in default configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,8 @@ const DEFAULT_CONFIGURATION = {
   reachabilityUrl: 'https://clients3.google.com/generate_204',
   reachabilityTest: (response: Response): Promise<boolean> =>
     Promise.resolve(response.status === 204),
-  reachabilityShortTimeout: 60 * 1000, // 60s
-  reachabilityLongTimeout: 5 * 1000, // 5s
+  reachabilityLongTimeout: 60 * 1000, // 60s
+  reachabilityShortTimeout: 5 * 1000, // 5s
 };
 
 // Stores the currently used configuration


### PR DESCRIPTION
# Overview
This corrects the reachability timeouts being swapped in the default configuration, thereby causing reachability checks to be repeated every 5 seconds if the previous reachability status was good and only every 60 seconds, otherwise.

# Test Plan
No issues were reported by ESLint and Jest.