### PR TITLE
fix: Add reachability request timeout to improve handling of bad network connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,12 +284,13 @@ Describes the current generation of the `cellular` connection. It is an enum wit
 #### `NetInfoConfiguration`
 The configuration options for the library.
 
-| Property                   | Type                              | Description                                                                                                                                                                                                                               |
-| -------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `reachabilityUrl`          | `string`                          | The URL to call to test if the internet is reachable. Only used on platforms which do not supply internet reachability natively.                                                                                                          |
-| `reachabilityTest`         | `(response: Response) => boolean` | A function which is passed the `Response` from calling the reachability URL. It should return `true` if the response indicates that the internet is reachable. Only used on platforms which do not supply internet reachability natively. |
-| `reachabilityShortTimeout` | `number`                          | The number of seconds between internet reachability checks when the internet was not previously detected. Only used on platforms which do not supply internet reachability natively.                                                      |
-| `reachabilityLongTimeout`  | `number`                          | The number of seconds between internet reachability checks when the internet was previously detected. Only used on platforms which do not supply internet reachability natively.                                                          |
+| Property                     | Type                              | Description                                                                                                                                                                                                                               |
+| ---------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `reachabilityUrl`            | `string`                          | The URL to call to test if the internet is reachable. Only used on platforms which do not supply internet reachability natively.                                                                                                          |
+| `reachabilityTest`           | `(response: Response) => boolean` | A function which is passed the `Response` from calling the reachability URL. It should return `true` if the response indicates that the internet is reachable. Only used on platforms which do not supply internet reachability natively. |
+| `reachabilityShortTimeout`   | `number`                          | The number of milliseconds between internet reachability checks when the internet was not previously detected. Only used on platforms which do not supply internet reachability natively.                                                 |
+| `reachabilityLongTimeout`    | `number`                          | The number of milliseconds between internet reachability checks when the internet was previously detected. Only used on platforms which do not supply internet reachability natively.                                                     |
+| `reachabilityRequestTimeout` | `number`                          | The number of milliseconds that a reachability check is allowed to take before failing. Only used on platforms which do not supply internet reachability natively.                                                                        |
 
 ### Methods
 
@@ -306,6 +307,7 @@ NetInfo.configure({
   reachabilityTest: async (response) => response.status === 204,
   reachabilityLongTimeout: 60 * 1000, // 60s
   reachabilityShortTimeout: 5 * 1000, // 5s
+  reachabilityRequestTimeout: 15 * 1000, // 15s
 });
 ```
 
@@ -358,6 +360,7 @@ const YourComponent = () => {
     reachabilityTest: async (response) => response.status === 204,
     reachabilityLongTimeout: 60 * 1000, // 60s
     reachabilityShortTimeout: 5 * 1000, // 5s
+    reachabilityRequestTimeout: 15 * 1000, // 15s
   });
 
   // ...

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ const DEFAULT_CONFIGURATION = {
     Promise.resolve(response.status === 204),
   reachabilityShortTimeout: 60 * 1000, // 60s
   reachabilityLongTimeout: 5 * 1000, // 5s
+  reachabilityRequestTimeout: 15 * 1000, // 15s
 };
 
 // Stores the currently used configuration

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -99,4 +99,5 @@ export interface NetInfoConfiguration {
   reachabilityTest: (response: Response) => Promise<boolean>;
   reachabilityLongTimeout: number;
   reachabilityShortTimeout: number;
+  reachabilityRequestTimeout: number;
 }


### PR DESCRIPTION
# Overview
This fixes an issue where a reachability check would not produce a result until a response from the reachability request is received. The fetch API, which is used for this purpose, does not have a built-in timeout mechanism, therefore requests can, in theory, stay pending forever. In case of a bad connection with packet loss, this can mean that no reachability issues are detected, even though there is effectively no internet connection. This commit aims to fix this issue by implementing a user-configurable request timeout.

One side-effect of the changes is that canceling a pending reachability check (see `InternetReachability_checkInternetReachability`) will immediately resolve the returned promise, instead of when the response is received, however I do not think this promise result is used anywhere at the moment.

# Test Plan
No issues were reported by ESLint and the current set of Jest tests. The changes have been tested on a real device.
