### PR TITLE
docs: Correct Jest mock import location

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ You should then add the following to your Jest setup file to mock the NetInfo Na
 
 ```js
 import { NativeModules } from 'react-native';
-import RNCNetInfoMock from './jest/netinfo-mock.js';
+import RNCNetInfoMock from '@react-native-community/netinfo/jest/netinfo-mock.js';
 
 NativeModules.RNCNetInfo = RNCNetInfoMock;
 ```


### PR DESCRIPTION
The mockup setup code in the readme was pointing to a `./jest` folder in the project root, while the `netinfo-mock.js` file is located in the `@react-native-community/netinfo/jest/netinfo-mock.js` directory.

This line was originally created in [this PR](https://github.com/react-native-community/react-native-netinfo/pull/275).