### PR TITLE
fix: Remove use of `Promise.prototype.finally` to prevent possible compatibility issues

### DIFF
--- a/src/internal/internetReachability.ts
+++ b/src/internal/internetReachability.ts
@@ -125,9 +125,14 @@ export default class InternetReachability {
           }
         },
       )
-      .finally(
+      // Clear request timeout and propagate any errors
+      .then(
         (): void => {
           clearTimeout(timeoutHandle);
+        },
+        (error: Error): void => {
+          clearTimeout(timeoutHandle);
+          throw error;
         },
       );
 


### PR DESCRIPTION
# Overview
This PR aims to fix an issue where `Promise.prototype.finally` is not available. While many platforms have native implementations available for this method, some libraries (probably targeting the web) appear to provide a polyfill for `Promise` regardless of any existing implementations (e.g. storybookjs/react-native#20). As it's probably easier to work around such issues here, this commit replaces the use of `finally` by a similar `then` construction. This fixes issue #309.

# Test Plan
The Jest tests currently fail due to #310, however they pass when rolled back to v5.4.0.
This has also been tested on simulators for iOS 10, 12 and 13.
