### PR TITLE
Update the mock binding method on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,9 +414,9 @@ You should then add the following to your Jest setup file to mock the NetInfo Na
 
 ```js
 import { NativeModules } from 'react-native';
-import RNCNetInfoMock from './jest/netinfo-mock.js';
+import RNCNetInfoMock from '@react-native-community/netinfo/jest/netinfo-mock.js';
 
-NativeModules.RNCNetInfo = RNCNetInfoMock;
+jest.mock('@react-native-community/netinfo', () => RNCNetInfoMock);
 ```
 
 ### Issues with the iOS simulator


### PR DESCRIPTION
# Overview
The doc guides mocking to `NativeModules.RNCNetInfo`, but it seems not works for me. instead mocking with `jest.mock` to `@react-native-community/netinfo`, it works.

