### PR TITLE
Only execute WifiManager.getConnectionInfo if ACCESS_WIFI_STATE is granted

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * <p>
+ *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- *
+ * <p>
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Locale;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -109,7 +110,7 @@ abstract class ConnectivityReceiver {
 
     private WritableMap createConnectivityEventMap(@Nullable final String requestedInterface) {
         WritableMap event = Arguments.createMap();
-      
+
         // Add if WiFi is ON or OFF
         boolean isEnabled = mWifiManager.isWifiEnabled();
         event.putBoolean("isWifiEnabled", isEnabled);
@@ -205,10 +206,10 @@ abstract class ConnectivityReceiver {
                             int mask =
                                     0xffffffff
                                             << (32
-                                                    - netAddress
-                                                            .getInterfaceAddresses()
-                                                            .get(1)
-                                                            .getNetworkPrefixLength());
+                                            - netAddress
+                                            .getInterfaceAddresses()
+                                            .get(1)
+                                            .getNetworkPrefixLength());
                             String subnet =
                                     String.format(
                                             Locale.US,

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -13,6 +13,7 @@ import android.net.ConnectivityManager;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.telephony.TelephonyManager;
+import android.util.Log;
 
 import androidx.core.content.ContextCompat;
 import androidx.core.net.ConnectivityManagerCompat;
@@ -161,68 +162,72 @@ abstract class ConnectivityReceiver {
             case "wifi":
                 if (ContextCompat.checkSelfPermission(getReactContext(),
                         Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED) {
-                    WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
-                    if (wifiInfo != null) {
-                        // Get the SSID
-                        try {
-                            String initialSSID = wifiInfo.getSSID();
-                            if (initialSSID != null && !initialSSID.contains("<unknown ssid>")) {
-                                // Strip the quotes, if any
-                                String ssid = initialSSID.replace("\"", "");
-                                details.putString("ssid", ssid);
+                    try {
+                        WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
+                        if (wifiInfo != null) {
+                            // Get the SSID
+                            try {
+                                String initialSSID = wifiInfo.getSSID();
+                                if (initialSSID != null && !initialSSID.contains("<unknown ssid>")) {
+                                    // Strip the quotes, if any
+                                    String ssid = initialSSID.replace("\"", "");
+                                    details.putString("ssid", ssid);
+                                }
+                            } catch (Exception e) {
+                                // Ignore errors
                             }
-                        } catch (Exception e) {
-                            // Ignore errors
-                        }
 
-                        // Get/parse the wifi signal strength
-                        try {
-                            int signalStrength =
-                                    WifiManager.calculateSignalLevel(wifiInfo.getRssi(), 100);
-                            details.putInt("strength", signalStrength);
-                        } catch (Exception e) {
-                            // Ignore errors
-                        }
+                            // Get/parse the wifi signal strength
+                            try {
+                                int signalStrength =
+                                        WifiManager.calculateSignalLevel(wifiInfo.getRssi(), 100);
+                                details.putInt("strength", signalStrength);
+                            } catch (Exception e) {
+                                // Ignore errors
+                            }
 
-                        // Get the IP address
-                        try {
-                            byte[] ipAddressByteArray =
-                                    BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
-                            NetInfoUtils.reverseByteArray(ipAddressByteArray);
-                            InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
-                            String ipAddress = inetAddress.getHostAddress();
-                            details.putString("ipAddress", ipAddress);
-                        } catch (Exception e) {
-                            // Ignore errors
-                        }
+                            // Get the IP address
+                            try {
+                                byte[] ipAddressByteArray =
+                                        BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
+                                NetInfoUtils.reverseByteArray(ipAddressByteArray);
+                                InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
+                                String ipAddress = inetAddress.getHostAddress();
+                                details.putString("ipAddress", ipAddress);
+                            } catch (Exception e) {
+                                // Ignore errors
+                            }
 
-                        // Get the subnet mask
-                        try {
-                            byte[] ipAddressByteArray =
-                                    BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
-                            NetInfoUtils.reverseByteArray(ipAddressByteArray);
-                            InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
-                            NetworkInterface netAddress =
-                                    NetworkInterface.getByInetAddress(inetAddress);
-                            int mask =
-                                    0xffffffff
-                                            << (32
-                                            - netAddress
-                                            .getInterfaceAddresses()
-                                            .get(1)
-                                            .getNetworkPrefixLength());
-                            String subnet =
-                                    String.format(
-                                            Locale.US,
-                                            "%d.%d.%d.%d",
-                                            (mask >> 24 & 0xff),
-                                            (mask >> 16 & 0xff),
-                                            (mask >> 8 & 0xff),
-                                            (mask & 0xff));
-                            details.putString("subnet", subnet);
-                        } catch (Exception e) {
-                            // Ignore errors
+                            // Get the subnet mask
+                            try {
+                                byte[] ipAddressByteArray =
+                                        BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
+                                NetInfoUtils.reverseByteArray(ipAddressByteArray);
+                                InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
+                                NetworkInterface netAddress =
+                                        NetworkInterface.getByInetAddress(inetAddress);
+                                int mask =
+                                        0xffffffff
+                                                << (32
+                                                - netAddress
+                                                .getInterfaceAddresses()
+                                                .get(1)
+                                                .getNetworkPrefixLength());
+                                String subnet =
+                                        String.format(
+                                                Locale.US,
+                                                "%d.%d.%d.%d",
+                                                (mask >> 24 & 0xff),
+                                                (mask >> 16 & 0xff),
+                                                (mask >> 8 & 0xff),
+                                                (mask & 0xff));
+                                details.putString("subnet", subnet);
+                            } catch (Exception e) {
+                                // Ignore errors
+                            }
                         }
+                    } catch (SecurityException e) {
+                        Log.e("ConnectivityReceiver", "ContextCompat.checkSelfPermission failed. Fail silently here instead.", e);
                     }
                 }
                 break;

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -14,6 +14,7 @@ import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.telephony.TelephonyManager;
 
+import androidx.core.content.ContextCompat;
 import androidx.core.net.ConnectivityManagerCompat;
 
 import com.facebook.react.bridge.Arguments;

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -6,7 +6,9 @@
  */
 package com.reactnativecommunity.netinfo;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
@@ -21,6 +23,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.reactnativecommunity.netinfo.types.CellularGeneration;
 import com.reactnativecommunity.netinfo.types.ConnectionType;
+
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -154,67 +157,70 @@ abstract class ConnectivityReceiver {
                 }
                 break;
             case "wifi":
-                WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
-                if (wifiInfo != null) {
-                    // Get the SSID
-                    try {
-                        String initialSSID = wifiInfo.getSSID();
-                        if (initialSSID != null && !initialSSID.contains("<unknown ssid>")) {
-                            // Strip the quotes, if any
-                            String ssid = initialSSID.replace("\"", "");
-                            details.putString("ssid", ssid);
+                if (ContextCompat.checkSelfPermission(getReactContext(),
+                        Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED) {
+                    WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
+                    if (wifiInfo != null) {
+                        // Get the SSID
+                        try {
+                            String initialSSID = wifiInfo.getSSID();
+                            if (initialSSID != null && !initialSSID.contains("<unknown ssid>")) {
+                                // Strip the quotes, if any
+                                String ssid = initialSSID.replace("\"", "");
+                                details.putString("ssid", ssid);
+                            }
+                        } catch (Exception e) {
+                            // Ignore errors
                         }
-                    } catch (Exception e) {
-                        // Ignore errors
-                    }
 
-                    // Get/parse the wifi signal strength
-                    try {
-                        int signalStrength =
-                                WifiManager.calculateSignalLevel(wifiInfo.getRssi(), 100);
-                        details.putInt("strength", signalStrength);
-                    } catch (Exception e) {
-                        // Ignore errors
-                    }
+                        // Get/parse the wifi signal strength
+                        try {
+                            int signalStrength =
+                                    WifiManager.calculateSignalLevel(wifiInfo.getRssi(), 100);
+                            details.putInt("strength", signalStrength);
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
 
-                    // Get the IP address
-                    try {
-                        byte[] ipAddressByteArray =
-                                BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
-                        NetInfoUtils.reverseByteArray(ipAddressByteArray);
-                        InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
-                        String ipAddress = inetAddress.getHostAddress();
-                        details.putString("ipAddress", ipAddress);
-                    } catch (Exception e) {
-                        // Ignore errors
-                    }
+                        // Get the IP address
+                        try {
+                            byte[] ipAddressByteArray =
+                                    BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
+                            NetInfoUtils.reverseByteArray(ipAddressByteArray);
+                            InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
+                            String ipAddress = inetAddress.getHostAddress();
+                            details.putString("ipAddress", ipAddress);
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
 
-                    // Get the subnet mask
-                    try {
-                        byte[] ipAddressByteArray =
-                                BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
-                        NetInfoUtils.reverseByteArray(ipAddressByteArray);
-                        InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
-                        NetworkInterface netAddress =
-                                NetworkInterface.getByInetAddress(inetAddress);
-                        int mask =
-                                0xffffffff
-                                        << (32
-                                                - netAddress
-                                                        .getInterfaceAddresses()
-                                                        .get(1)
-                                                        .getNetworkPrefixLength());
-                        String subnet =
-                                String.format(
-                                        Locale.US,
-                                        "%d.%d.%d.%d",
-                                        (mask >> 24 & 0xff),
-                                        (mask >> 16 & 0xff),
-                                        (mask >> 8 & 0xff),
-                                        (mask & 0xff));
-                        details.putString("subnet", subnet);
-                    } catch (Exception e) {
-                        // Ignore errors
+                        // Get the subnet mask
+                        try {
+                            byte[] ipAddressByteArray =
+                                    BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
+                            NetInfoUtils.reverseByteArray(ipAddressByteArray);
+                            InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
+                            NetworkInterface netAddress =
+                                    NetworkInterface.getByInetAddress(inetAddress);
+                            int mask =
+                                    0xffffffff
+                                            << (32
+                                                    - netAddress
+                                                            .getInterfaceAddresses()
+                                                            .get(1)
+                                                            .getNetworkPrefixLength());
+                            String subnet =
+                                    String.format(
+                                            Locale.US,
+                                            "%d.%d.%d.%d",
+                                            (mask >> 24 & 0xff),
+                                            (mask >> 16 & 0xff),
+                                            (mask >> 8 & 0xff),
+                                            (mask & 0xff));
+                            details.putString("subnet", subnet);
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
                     }
                 }
                 break;

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -13,7 +13,6 @@ import android.net.ConnectivityManager;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.telephony.TelephonyManager;
-import android.util.Log;
 
 import androidx.core.content.ContextCompat;
 import androidx.core.net.ConnectivityManagerCompat;
@@ -162,72 +161,68 @@ abstract class ConnectivityReceiver {
             case "wifi":
                 if (ContextCompat.checkSelfPermission(getReactContext(),
                         Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED) {
-                    try {
-                        WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
-                        if (wifiInfo != null) {
-                            // Get the SSID
-                            try {
-                                String initialSSID = wifiInfo.getSSID();
-                                if (initialSSID != null && !initialSSID.contains("<unknown ssid>")) {
-                                    // Strip the quotes, if any
-                                    String ssid = initialSSID.replace("\"", "");
-                                    details.putString("ssid", ssid);
-                                }
-                            } catch (Exception e) {
-                                // Ignore errors
+                    WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
+                    if (wifiInfo != null) {
+                        // Get the SSID
+                        try {
+                            String initialSSID = wifiInfo.getSSID();
+                            if (initialSSID != null && !initialSSID.contains("<unknown ssid>")) {
+                                // Strip the quotes, if any
+                                String ssid = initialSSID.replace("\"", "");
+                                details.putString("ssid", ssid);
                             }
-
-                            // Get/parse the wifi signal strength
-                            try {
-                                int signalStrength =
-                                        WifiManager.calculateSignalLevel(wifiInfo.getRssi(), 100);
-                                details.putInt("strength", signalStrength);
-                            } catch (Exception e) {
-                                // Ignore errors
-                            }
-
-                            // Get the IP address
-                            try {
-                                byte[] ipAddressByteArray =
-                                        BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
-                                NetInfoUtils.reverseByteArray(ipAddressByteArray);
-                                InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
-                                String ipAddress = inetAddress.getHostAddress();
-                                details.putString("ipAddress", ipAddress);
-                            } catch (Exception e) {
-                                // Ignore errors
-                            }
-
-                            // Get the subnet mask
-                            try {
-                                byte[] ipAddressByteArray =
-                                        BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
-                                NetInfoUtils.reverseByteArray(ipAddressByteArray);
-                                InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
-                                NetworkInterface netAddress =
-                                        NetworkInterface.getByInetAddress(inetAddress);
-                                int mask =
-                                        0xffffffff
-                                                << (32
-                                                - netAddress
-                                                .getInterfaceAddresses()
-                                                .get(1)
-                                                .getNetworkPrefixLength());
-                                String subnet =
-                                        String.format(
-                                                Locale.US,
-                                                "%d.%d.%d.%d",
-                                                (mask >> 24 & 0xff),
-                                                (mask >> 16 & 0xff),
-                                                (mask >> 8 & 0xff),
-                                                (mask & 0xff));
-                                details.putString("subnet", subnet);
-                            } catch (Exception e) {
-                                // Ignore errors
-                            }
+                        } catch (Exception e) {
+                            // Ignore errors
                         }
-                    } catch (SecurityException e) {
-                        Log.e("ConnectivityReceiver", "ContextCompat.checkSelfPermission failed. Fail silently here instead.", e);
+
+                        // Get/parse the wifi signal strength
+                        try {
+                            int signalStrength =
+                                    WifiManager.calculateSignalLevel(wifiInfo.getRssi(), 100);
+                            details.putInt("strength", signalStrength);
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
+
+                        // Get the IP address
+                        try {
+                            byte[] ipAddressByteArray =
+                                    BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
+                            NetInfoUtils.reverseByteArray(ipAddressByteArray);
+                            InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
+                            String ipAddress = inetAddress.getHostAddress();
+                            details.putString("ipAddress", ipAddress);
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
+
+                        // Get the subnet mask
+                        try {
+                            byte[] ipAddressByteArray =
+                                    BigInteger.valueOf(wifiInfo.getIpAddress()).toByteArray();
+                            NetInfoUtils.reverseByteArray(ipAddressByteArray);
+                            InetAddress inetAddress = InetAddress.getByAddress(ipAddressByteArray);
+                            NetworkInterface netAddress =
+                                    NetworkInterface.getByInetAddress(inetAddress);
+                            int mask =
+                                    0xffffffff
+                                            << (32
+                                            - netAddress
+                                            .getInterfaceAddresses()
+                                            .get(1)
+                                            .getNetworkPrefixLength());
+                            String subnet =
+                                    String.format(
+                                            Locale.US,
+                                            "%d.%d.%d.%d",
+                                            (mask >> 24 & 0xff),
+                                            (mask >> 16 & 0xff),
+                                            (mask >> 8 & 0xff),
+                                            (mask & 0xff));
+                            details.putString("subnet", subnet);
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

The motivation behind this PR is to allow apps to remove ACCESS_WIFI_STATE permission in their app, without the app crashing. We have a case in one of our partner apps where we use netinfo for some network logging, but we don't use all the data collected by netinfo, e.g. wifi data. 
We shouldn't crash because of missing permissions, just reduce the data collected.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Before this change:
AndroidManifest.xml in the Android app

     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" tools:node="remove" />

logcat:

     java.lang.SecurityException: WifiService: Neither user 10403 nor current process has android.permission.ACCESS_WIFI_STATE.
    at android.os.Parcel.createException(Parcel.java:2088)
    at android.os.Parcel.readException(Parcel.java:2056)
    at android.os.Parcel.readException(Parcel.java:2004)
    at android.net.wifi.IWifiManager$Stub$Proxy.getConnectionInfo(IWifiManager.java:3405)
    at android.net.wifi.WifiManager.getConnectionInfo(WifiManager.java:2727)
    at com.reactnativecommunity.netinfo.ConnectivityReceiver.d(SourceFile:127)
    at com.reactnativecommunity.netinfo.ConnectivityReceiver.getCurrentState(SourceFile:56)
    at com.reactnativecommunity.netinfo.NetInfoModule.getCurrentState(SourceFile:50)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.facebook.react.bridge.JavaMethodWrapper.invoke(SourceFile:371)
    at com.facebook.react.bridge.JavaModuleWrapper.invoke(SourceFile:150)
    at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(SourceFile:26)
    at android.os.Looper.loop(Looper.java:237)
    at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(SourceFile:225)
    at java.lang.Thread.run(Thread.java:919)

After this change:
🟢