### PR TITLE
[Work in progress] Check if bluetooth is enabled

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,5 +8,11 @@
 	<uses-permission
 		android:name="android.permission.ACCESS_WIFI_STATE" />
 
+	<uses-permission
+			android:name="android.permission.BLUETOOTH" />
+
+	<uses-permission
+			android:name="android.permission.ACCESS_FINE_LOCATION" />
+
 </manifest>
   

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -38,6 +38,7 @@ abstract class ConnectivityReceiver {
     private final ConnectivityManager mConnectivityManager;
     private final WifiManager mWifiManager;
     private final TelephonyManager mTelephonyManager;
+    private final BluetoothManager mBluetoothManager;
     private final ReactApplicationContext mReactContext;
 
     @Nonnull private ConnectionType mConnectionType = ConnectionType.UNKNOWN;
@@ -54,6 +55,8 @@ abstract class ConnectivityReceiver {
                         reactContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         mTelephonyManager =
                 (TelephonyManager) reactContext.getSystemService(Context.TELEPHONY_SERVICE);
+        mbluetoothManager =
+                (BluetoothManager) = reactContext.getSystemService(Context.BLUETOOTH_SERVICE);
     }
 
     abstract void register();
@@ -115,6 +118,15 @@ abstract class ConnectivityReceiver {
         // Add if WiFi is ON or OFF
         boolean isEnabled = mWifiManager.isWifiEnabled();
         event.putBoolean("isWifiEnabled", isEnabled);
+
+        // Check if bluetooth is enabled
+        BluetoothAdapter mBluetoothAdapter = mBluetoothManager.getAdapter();
+        boolean isBluetoothEnabled;
+        if (mBluetoothAdapter == null) {
+            isBluetoothEnabled = false;
+        } else {
+            isBluetoothEnabled = mBluetoothAdapter.isEnabled();
+        }
 
         // Add the connection type information
         event.putString("type", requestedInterface != null ? requestedInterface : mConnectionType.label);

--- a/package.json
+++ b/package.json
@@ -142,8 +142,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "yarn test"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
# Overview

***THIS DOES NOT WORK YET, DO NOT MERGE, I AM JUST LOOKING AROUND***

Resolves https://github.com/react-native-community/react-native-netinfo/issues/339

I need to check if the Bluetooth is enabled on the device (not only check the connection) so I am attempting to add this field to the API. 

This would perform similarly to [isWifiEnabled](https://github.com/react-native-community/react-native-netinfo#netinfostate) 

### Relevant information 

- [Android general bluetooth overview](https://developer.android.com/guide/topics/connectivity/bluetooth)
- we can get the `BluetoothManager` in a similar way we do with the `WifiManager` as per: https://developer.android.com/reference/android/bluetooth/BluetoothManager
- From this we can get an instance of `BluetoothAdadpter` via [getAdapter](https://developer.android.com/reference/android/bluetooth/BluetoothManager#getAdapter())
- Bluetooth Adapter exposes [isEnabled()](https://developer.android.com/guide/topics/connectivity/bluetooth#SettingUp) which tells us the information we want

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
