### PR TITLE
fix(tests): fix the mock variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,9 +430,9 @@ setupFiles: ['<rootDir>/jest.setup.js']
 You should then add the following to your Jest setup file to mock the NetInfo Native Module:
 
 ```js
-import RNCNetInfoMock from '@react-native-community/netinfo/jest/netinfo-mock.js';
+import mockRNCNetInfo from '@react-native-community/netinfo/jest/netinfo-mock.js';
 
-jest.mock('@react-native-community/netinfo', () => RNCNetInfoMock);
+jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo);
 ```
 
 ### Issues with the iOS simulator


### PR DESCRIPTION
The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables.

Note: This is a precaution to guard against uninitialized mock variables. If it is ensured that the mock is required lazily, variable names prefixed with `mock` (case insensitive) are permitted.

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
