### PR TITLE
BSSID adition to WIFI type

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ The `details` value depends on the `type` value.
 | ----------------------- | --------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `isConnectionExpensive` | Android, iOS, macOS, Windows, Web | `boolean` | If the network connection is considered "expensive". This could be in either energy or monetary terms.                     |
 | `ssid`                  | Android, iOS (not tvOS)           | `string`  | The SSID of the network. May not be present, `null`, or an empty string if it cannot be determined. **On iOS, make sure your app meets at least one of the [following requirements](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo?language=objc#discussion). On Android, you need to have the `ACCESS_FINE_LOCATION` permission in your `AndroidManifest.xml` and accepted by the user**. |
+| `bssid`                 | Android, iOS (not tvOS)           | `string`  | The BSSID of the network. May not be present, `null`, or an empty string if it cannot be determined. **On iOS, make sure your app meets at least one of the [following requirements](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo?language=objc#discussion). On Android, you need to have the `ACCESS_FINE_LOCATION` permission in your `AndroidManifest.xml` and accepted by the user**. |
 | `strength`              | Android                           | `number`  | An integer number from `0` to `5` for the signal strength. May not be present if the signal strength cannot be determined. |
 | `ipAddress`             | Android, iOS, macOS               | `string`  | The external IP address. Can be in IPv4 or IPv6 format. May not be present if it cannot be determined.                     |
 | `subnet`                | Android, iOS, macOS               | `string`  | The subnet mask in IPv4 format. May not be present if it cannot be determined.                                             |
@@ -415,6 +416,7 @@ You can optionally send an `interface` string so the `Promise` resolves to a [`N
 ```javascript
 NetInfo.fetch("wifi").then(state => {
   console.log("SSID", state.details.ssid);
+  console.log("BSSID", state.details.bssid);
   console.log("Is connected?", state.isConnected);
 });
 ```

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -177,6 +177,17 @@ abstract class ConnectivityReceiver {
                             // Ignore errors
                         }
 
+                        // Get the BSSID
+                        try {
+                            String bssid = wifiInfo.getBSSID();
+                            if (bssid != null) {
+                                details.putString("bssid", bssid);
+                            }
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
+
+
                         // Get/parse the wifi signal strength
                         try {
                             int signalStrength =

--- a/ios/RNCNetInfo.m
+++ b/ios/RNCNetInfo.m
@@ -106,7 +106,7 @@ RCT_EXPORT_METHOD(getCurrentState:(nullable NSString *)requestedInterface resolv
   if (connected) {
     details[@"isConnectionExpensive"] = @(state.expensive);
   }
-  
+
   return @{
     @"type": selectedInterface,
     @"isConnected": @(connected),
@@ -125,6 +125,7 @@ RCT_EXPORT_METHOD(getCurrentState:(nullable NSString *)requestedInterface resolv
     details[@"subnet"] = [self subnet] ?: NSNull.null;
     #if !TARGET_OS_TV && !TARGET_OS_OSX
     details[@"ssid"] = [self ssid] ?: NSNull.null;
+    details[@"bssid"] = [self bssid] ?: NSNull.null;
     #endif
   }
   return details;
@@ -166,7 +167,7 @@ RCT_EXPORT_METHOD(getCurrentState:(nullable NSString *)requestedInterface resolv
           address = [NSString stringWithUTF8String:inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_addr)->sin_addr)];
         }
       }
-      
+
       temp_addr = temp_addr->ifa_next;
     }
   }
@@ -200,7 +201,7 @@ RCT_EXPORT_METHOD(getCurrentState:(nullable NSString *)requestedInterface resolv
           subnet = [NSString stringWithUTF8String:inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_netmask)->sin_addr)];
         }
       }
-      
+
       temp_addr = temp_addr->ifa_next;
     }
   }
@@ -226,6 +227,22 @@ RCT_EXPORT_METHOD(getCurrentState:(nullable NSString *)requestedInterface resolv
     }
   }
   return SSID;
+}
+
+- (NSString *)bssid
+{
+  NSArray *interfaceNames = CFBridgingRelease(CNCopySupportedInterfaces());
+  NSDictionary *networkDetails;
+  NSString *BSSID = NULL;
+  for (NSString *interfaceName in interfaceNames) {
+      networkDetails = CFBridgingRelease(CNCopyCurrentNetworkInfo((__bridge CFStringRef)interfaceName));
+      if (networkDetails.count > 0)
+      {
+          BSSID = networkDetails[(NSString *) kCNNetworkInfoKeyBSSID];
+          break;
+      }
+  }
+  return BSSID;
 }
 #endif
 

--- a/src/internal/defaultConfiguration.web.ts
+++ b/src/internal/defaultConfiguration.web.ts
@@ -3,6 +3,6 @@ export default {
   reachabilityTest: (response: Response): Promise<boolean> =>
     Promise.resolve(response.status === 200),
   reachabilityShortTimeout: 5 * 1000, // 5s
-  reachabilityLongTimeout: 60 * 1000, // 60s  
+  reachabilityLongTimeout: 60 * 1000, // 60s
   reachabilityRequestTimeout: 15 * 1000, // 15s
 };


### PR DESCRIPTION
# Overview
Added BSSID information to the wifi type.

# Test Plan
Implementation is basically the same as for SSID. 
Added in the readme how to test it (together with the SSID example).

Fixes #360 