### PR TITLE
Add method to read WiFi frequency for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ The `details` value depends on the `type` value.
 | `strength`              | Android                           | `number`  | An integer number from `0` to `5` for the signal strength. May not be present if the signal strength cannot be determined. |
 | `ipAddress`             | Android, iOS, macOS               | `string`  | The external IP address. Can be in IPv4 or IPv6 format. May not be present if it cannot be determined.                     |
 | `subnet`                | Android, iOS, macOS               | `string`  | The subnet mask in IPv4 format. May not be present if it cannot be determined.                                             |
+| `frequency`             | Android                           | `number`  | Network frequency. Example: For 2.4 GHz networks, the method will return 2457. May not be present if it cannot be determined.                                             |
 
 ##### `type` is `cellular`
 

--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -186,6 +186,14 @@ abstract class ConnectivityReceiver {
                             // Ignore errors
                         }
 
+                        // Get WiFi frequency
+                        try {
+                            int frequency = wifiInfo.getFrequency();
+                            details.putInt("frequency", frequency);
+                        } catch (Exception e) {
+                            // Ignore errors
+                        }
+
                         // Get the IP address
                         try {
                             byte[] ipAddressByteArray =

--- a/src/internal/nativeModule.web.ts
+++ b/src/internal/nativeModule.web.ts
@@ -182,8 +182,10 @@ const getCurrentState = (
       type,
       details: {
         isConnectionExpensive,
+        ssid: null,
         ipAddress: null,
         subnet: null,
+        frequency: null,
       },
     };
     return state;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -66,8 +66,10 @@ export type NetInfoCellularState = NetInfoConnectedState<
 export type NetInfoWifiState = NetInfoConnectedState<
   NetInfoStateType.wifi,
   {
+    ssid: string | null;
     ipAddress: string | null;
     subnet: string | null;
+    frequency: number | null;
   }
 >;
 export type NetInfoBluetoothState = NetInfoConnectedState<


### PR DESCRIPTION
# Overview

Added WiFi network frequency to WiFi Network State. [Used Android SDK method description](https://developer.android.com/reference/android/net/wifi/WifiInfo.html#getFrequency()).
Example: for 2.4 GHz networks, the `frequency` will be `2457`.

Unfortunately, iOS does not allow to access a connected WiFi frequency, so the property is missing for iOS

### Example Android

Here is the screenshot of `NetInfo.fetch()` result for Android on 5GHz network:

<img width="232" alt="Screenshot 2020-05-17 at 21 17 49" src="https://user-images.githubusercontent.com/17258145/82157136-5b1fb400-9888-11ea-9c46-6b7d366991b8.png">

### Example iOS

Here is the screenshot of `NetInfo.fetch()` result for iOS on the same5GHz network.
As I mentioned, the `frequency` property is missing

<img width="267" alt="Screenshot 2020-05-17 at 22 15 52" src="https://user-images.githubusercontent.com/17258145/82157772-1f86e900-988c-11ea-9fde-9507a0318ed9.png">


# Test Plan

I've extended the `createDetailsMap` at `ConnectivityReceiver.java`. In case a device uses WiFi, we'll extract the frequency from `WifiInfo`. So you can call `NetInfo.fetch()` on any Android phone and `frequency` has to appear in the `details` object.