### PR TITLE
fix Pods installation on macOS

### DIFF
--- a/react-native-netinfo.podspec
+++ b/react-native-netinfo.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "9.0", :tvos => "9.2" }
+  s.platforms    = { :ios => "9.0", :tvos => "9.2", :osx => "10.14" }
 
   s.source       = { :git => "https://github.com/react-native-community/react-native-netinfo.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
# Overview

Refs #312

This small PR updates the `podspec` file and adds `osx` platform there which fixes Pods installation for the macOS platform:

<img width="1107" alt="Screenshot 2020-05-21 at 23 57 22" src="https://user-images.githubusercontent.com/719641/82611135-1796b400-9bc0-11ea-888c-b80417ab30cc.png">

# Test Plan

I have tested the change on the local working copy of `react-native-netinfo`.