### PR TITLE
Do not use getFrequency method for Android lower than LOLLIPOP

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
+++ b/android/src/main/java/com/reactnativecommunity/netinfo/ConnectivityReceiver.java
@@ -199,8 +199,10 @@ abstract class ConnectivityReceiver {
 
                         // Get WiFi frequency
                         try {
-                            int frequency = wifiInfo.getFrequency();
-                            details.putInt("frequency", frequency);
+                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+                                int frequency = wifiInfo.getFrequency();
+                                details.putInt("frequency", frequency);
+                            }
                         } catch (Exception e) {
                             // Ignore errors
                         }


### PR DESCRIPTION
# Overview
Supported version is 16 for Android, but used method is not fitting in this minimum version

Fixes #365

# Test Plan
Run it on old Android devices with Android lower than v5 (API 21)
