### PR TITLE
[fix] Add missing isWifiEnabled type definition

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -37,6 +37,7 @@ interface NetInfoConnectedState<
   isConnected: true;
   isInternetReachable: boolean | null | undefined;
   details: D & NetInfoConnectedDetails;
+  isWifiEnabled?: boolean;
 }
 
 interface NetInfoDisconnectedState<T extends NetInfoStateType> {


### PR DESCRIPTION
# Overview
While using this package I noticed the `isWifiEnabled` boolean on the `NetInfoState` object for Android only (mentioned in the README [here](https://github.com/react-native-community/react-native-netinfo#netinfostate)), but this was missing from the Typescript definitions.

This PR adds the `isWifiEnabled` boolean to the type (missed from https://github.com/react-native-community/react-native-netinfo/pull/255). 🙂

It has been typed as an optional `boolean` as it is only available on Android.
